### PR TITLE
Invert the display at the cursor position

### DIFF
--- a/src/view.mm
+++ b/src/view.mm
@@ -177,9 +177,6 @@
     [self drawCursor];
 }
 
-/* Draw a shitty cursor. TODO: Either:
-    1) Figure out how to make Cocoa invert the display at the cursor pos
-    2) Start keeping a screen character buffer */
 - (void)drawCursor
 {
     NSRect cellRect;
@@ -190,11 +187,11 @@
     if (mInsertMode || y + 1 == mYCells)
         cellRect = CGRectMake(x, y, .2, 1);
     else
-        cellRect = CGRectMake(x, y+1, 1, .3);
+        cellRect = CGRectMake(x, y, 1, 1);
 
     NSRect viewRect = [self viewRectFromCellRect:cellRect];
-    [mForegroundColor set];
-    NSRectFill(viewRect);
+    [[NSColor whiteColor] set];
+    NSRectFillUsingOperation(viewRect, NSCompositeDifference);
 }
 
 


### PR DESCRIPTION
This patch draws the cursor by drawing a white rectangle with blend mode NSCompositeDifference, which has the effect of inverting the display.