### PR TITLE
Add 'brew tap' to README so neovim installation works

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Pull requests are welcome, and greatly appreciated!
     $ brew install msgpack
 
 #### A NeoVim binary
+    $ brew tap neovim/homebrew-neovim
     $ brew install --HEAD neovim
 
 ### To compile:


### PR DESCRIPTION
I tried installing neovim-dot-app by following the README.md instructions, but the `brew install neovim` command failed. This is what I found to make it work.