### PR TITLE
Support Japanese Keyboard Layout

### DIFF
--- a/res/Info.plist
+++ b/res/Info.plist
@@ -29,5 +29,19 @@
         <key>CFBundleIconFile</key>
         <string>Neovim</string>
 
+        <key>CFBundleDocumentTypes</key>
+        <array>
+            <dict>
+                <key>CFBundleTypeName</key>
+                <string>All Files</string>
+                <key>LSHandlerRank</key>
+                <string>Alternate</string>
+                <key>LSItemContentTypes</key>
+                <array>
+                    <string>public.data</string>
+                    <string>public.content</string>
+                </array>
+            </dict>
+        </array>
     </dict>
 </plist>

--- a/src/keys.mm
+++ b/src/keys.mm
@@ -65,6 +65,15 @@ static NSString *stringFromModifiedKey(unsigned keyCode, unsigned modifiers)
         kTISPropertyUnicodeKeyLayoutData
     );
 
+    if(!layoutData) {
+        keyboard = TISCopyCurrentASCIICapableKeyboardLayoutInputSource();
+        layoutData = (CFDataRef)TISGetInputSourceProperty(keyboard, kTISPropertyUnicodeKeyLayoutData);
+    }
+
+    if (!layoutData) {
+        return nil;
+    }
+
     const UCKeyboardLayout *layout =
         (const UCKeyboardLayout *)CFDataGetBytePtr(layoutData);
 

--- a/src/view.h
+++ b/src/view.h
@@ -5,7 +5,7 @@ class Vim;
 
 @class NSImage;
 
-@interface VimView : NSView {
+@interface VimView : NSView<NSDraggingDestination> {
     Vim *mVim;
 
     CGContextRef mCanvasContext;

--- a/src/view.mm
+++ b/src/view.mm
@@ -67,6 +67,8 @@
 
         mCursorPos = mCursorDisplayPos = CGPointZero;
         mCursorOn = true;
+        
+        [self registerForDraggedTypes:[NSArray arrayWithObjects: NSFilenamesPboardType, nil]];
     }
 
     return self;
@@ -156,6 +158,58 @@
     filename = [@"e " stringByAppendingString:filename];
     mVim->vim_command([filename UTF8String]);
 }
+
+- (NSDragOperation)draggingEntered:(id <NSDraggingInfo>)sender
+{
+    NSPasteboard *pboard;
+    NSDragOperation sourceDragMask;
+
+    sourceDragMask = [sender draggingSourceOperationMask];
+    pboard = [sender draggingPasteboard];
+
+    if ( [[pboard types] containsObject:NSFilenamesPboardType] )
+    {
+        return NSDragOperationCopy;
+    }
+    return NSDragOperationNone;
+}
+
+- (NSDragOperation)draggingUpdated:(id<NSDraggingInfo>)sender
+{
+    NSPasteboard *pboard;
+    NSDragOperation sourceDragMask;
+
+    sourceDragMask = [sender draggingSourceOperationMask];
+    pboard = [sender draggingPasteboard];
+
+    if ( [[pboard types] containsObject:NSFilenamesPboardType] )
+    {
+        return NSDragOperationCopy;
+    }
+    return NSDragOperationNone;
+}
+
+- (BOOL)prepareForDragOperation:(id<NSDraggingInfo>)sender
+{
+    return YES;
+}
+
+- (BOOL)performDragOperation:(id<NSDraggingInfo>)sender
+{
+    NSPasteboard *pboard = [sender draggingPasteboard];
+    if ([[pboard types] containsObject:NSURLPboardType]) {
+        NSArray *urls = [pboard readObjectsForClasses:@[[NSURL class]] options:nil];
+        NSURL *firstURL = [urls objectAtIndex:0];
+        NSString *path = [[firstURL filePathURL] absoluteString];
+        [self openFile: path];
+    }
+    return YES;
+}
+
+- (void)concludeDragOperation:(id<NSDraggingInfo>)sender 
+{
+}
+
 
 /*  When drawing, it's important that our canvas image is in the same color
     space as the destination, otherwise drawing will be very slow. */


### PR DESCRIPTION
Neovim.app crashed when using Japanese 英字 layout. 
This pull request tries to load a ASCII capable version and converts the keys to letters with that instead if the unicode version fails.