### PR TITLE
Support Japanese Keyboard Layout

### DIFF
--- a/src/keys.mm
+++ b/src/keys.mm
@@ -65,6 +65,15 @@ static NSString *stringFromModifiedKey(unsigned keyCode, unsigned modifiers)
         kTISPropertyUnicodeKeyLayoutData
     );
 
+    if(!layoutData) {
+        keyboard = TISCopyCurrentASCIICapableKeyboardLayoutInputSource();
+        layoutData = (CFDataRef)TISGetInputSourceProperty(keyboard, kTISPropertyUnicodeKeyLayoutData);
+    }
+
+    if (!layoutData) {
+        return nil;
+    }
+
     const UCKeyboardLayout *layout =
         (const UCKeyboardLayout *)CFDataGetBytePtr(layoutData);
 


### PR DESCRIPTION
Neovim.app crashed when using Japanese 英字 layout. 
This pull request tries to load a ASCII capable version and converts the keys to letters with that instead if the unicode version fails.