### PR TITLE
Add 'make install' option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,6 @@ all:
 
 clean:
 	$(RM) -r build
+
+install:
+	cp -fpRv "build/Neovim.app" "/Applications/Neovim.app"


### PR DESCRIPTION
Adds a very simple 'make install' option to copy Neovim.app from build directory to /Applications/Neovim.app

Signed-off-by: Jocelyn Mallon <jocelyn.e.mallon@gmail.com>