### PR TITLE
add install in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,6 @@ all:
 
 clean:
 	$(RM) -r build
+
+install:
+	cp -fpRv "build/Neovim.app" "/Applications/Neovim.app"


### PR DESCRIPTION
This adds a simple 'install' option to the makefile, which copies Neovim.app from the build directory to /Applications/Neovim.app