### PR TITLE
fix make install path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,4 @@ clean:
 	$(RM) -r build
 
 install:
-	cp -fpRv "build/Neovim.app" "/Applications/Neovim.app"
+	cp -fpRv "build/Neovim.app" "/Applications"


### PR DESCRIPTION
Fix the path in make install so successive runs no longer create nested copies of Neovim.app, e.g. /Applications/Neovim.app/Neovim.app