### PR TITLE
On focus, ask nvim to check if any buffers were changed outside

### DIFF
--- a/src/app.mm
+++ b/src/app.mm
@@ -40,6 +40,7 @@ static NSWindow *window = 0;
 - (void)windowDidBecomeKey:(NSNotification *)notification
 {
     vim->vim_command("silent! doautoall <nomodeline> FocusGained");
+    vim->vim_command("checktime");
 }
 
 - (void)windowDidResignKey:(NSNotification *)notification


### PR DESCRIPTION
* This makes Neovim.app behave like MacVim when buffers are changed
* Reading the [documentation](https://github.com/neovim/neovim/blob/98413a4932852a0e6cc94ee490334ebd07f03fa9/runtime/doc/editing.txt#L1379) on `:checktime` we could ask nvim to only
  check the current buffer instead of all the buffers as a slight optimisation