### PR TITLE
Fetch environment variables from a login shell on launch

### DIFF
--- a/src/app.mm
+++ b/src/app.mm
@@ -67,6 +67,73 @@ static NSWindow *window = 0;
     return YES;
 }
 
+- (NSDictionary *)environmentFromLoginShell:(NSString *)shellPath
+{
+    if (!shellPath.length) {
+        return nil;
+    }
+
+    NSArray *args = @[@"-l", @"-c", @"\"env\""];
+    NSTask *task = [NSTask new];
+    task.launchPath = shellPath;
+    task.arguments = args;
+    task.standardOutput = [NSPipe new];
+    task.standardError = [NSPipe new];
+    [task launch];
+    [task waitUntilExit];
+
+    if (task.terminationStatus != EXIT_SUCCESS) {
+        NSData *stderrData = ((NSPipe *)task.standardError).fileHandleForReading.readDataToEndOfFile;
+        NSString *stderror = [[NSString alloc] initWithData:stderrData encoding:NSUTF8StringEncoding];
+        NSLog(@"%@ %@ failed: %@", task.launchPath, [task.arguments componentsJoinedByString:@" "], stderror);
+        return nil;
+    }
+
+    NSData *stdoutData = ((NSPipe *)task.standardOutput).fileHandleForReading.readDataToEndOfFile;
+    NSString *envString = [[NSString alloc] initWithData:stdoutData encoding:NSUTF8StringEncoding];
+    NSArray *envVars = [envString componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]];
+    NSMutableDictionary *env = [NSMutableDictionary new];
+
+    for (NSString *s in envVars) {
+        NSArray *keyvalue = [s componentsSeparatedByString:@"="];
+
+        if (keyvalue.count < 2) {
+            continue;
+        }
+
+        NSString *key = keyvalue[0];
+        NSString *value = keyvalue[1];
+
+        env[key] = value;
+    }
+
+    return env;
+}
+
+/**  
+ *  Attempt to get the environment dictionary for the user's chosen shell,
+ *  using the $SHELL environment variable.
+ *  
+ *  If that fails, try again using /bin/bash, which should always be available on OSX.
+ */
+- (void)loadLoginShellEnvironmentVariables
+{
+    NSString *shellPath = [[NSProcessInfo processInfo] environment][@"SHELL"];
+    NSDictionary *env = [self environmentFromLoginShell:shellPath];
+    if (!env) {
+        shellPath = @"/bin/bash";
+        env = [self environmentFromLoginShell:shellPath];
+    }
+
+    if (!env) {
+        NSLog(@"Couldn't get environment from $SHELL or /bin/bash, defaulting to existing environment.");
+    } else {
+        [env enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSString *value, BOOL *stop) {
+            setenv(key.UTF8String, value.UTF8String, 1);
+        }];
+    }
+}
+
 - (void)applicationWillFinishLaunching:(NSNotification *)notification
 {
     [NSFontManager setFontManagerFactory:[VimFontManager class]];
@@ -74,9 +141,9 @@ static NSWindow *window = 0;
 
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     [defaults registerDefaults:@{@"width": @80,
-                                @"height": @25,
-                              @"fontName": @"Menlo",
-                              @"fontSize": @11.0}];
+                                 @"height": @25,
+                                 @"fontName": @"Menlo",
+                                 @"fontSize": @11.0}];
 
     int width = [defaults integerForKey:@"width"];
     int height = [defaults integerForKey:@"height"];
@@ -90,40 +157,7 @@ static NSWindow *window = 0;
     NSString *vimPath = [[NSBundle mainBundle] pathForResource:@"nvim"
                                                         ofType:nil];
 
-    const char *envShell = getenv("SHELL");
-    size_t envShellLength = envShell ? strlen(envShell) : 0;
-    NSString *shell = [[NSString alloc] initWithData:[NSData dataWithBytes:envShell length:envShellLength]
-                                            encoding:NSUTF8StringEncoding];
-
-    // Handle the case where `getenv` returns an empty string (but not NULL)
-    if (!shell.length) {
-        shell = @"/bin/bash";
-    }
-
-    NSArray *args = @[@"-l -c", @"\"env\""];
-    NSTask *task = [NSTask new];
-    task.launchPath = shell;
-    task.arguments = args;
-    task.standardOutput = [NSPipe new];
-    [task launch];
-    [task waitUntilExit];
-    NSString *env = [[NSString alloc] initWithData:((NSPipe *)task.standardOutput).fileHandleForReading.readDataToEndOfFile encoding:NSUTF8StringEncoding];
-    NSArray *envVars = [env componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]];
-
-    for (NSString *envVar in envVars) {
-        NSArray *keyvalue = [envVar componentsSeparatedByString:@"="];
-
-        if (keyvalue.count < 2) {
-            continue;
-        }
-
-        NSString *key = keyvalue[0];
-        NSString *value = keyvalue[1];
-
-        char *old = getenv(key.UTF8String);
-
-        setenv(key.UTF8String, value.UTF8String, 1);
-    }
+    [self loadLoginShellEnvironmentVariables];
 
     /* Set both VIM and NVIM for now. TODO: Remove VIM when
        https://github.com/neovim/neovim/pull/1927 is merged */

--- a/src/app.mm
+++ b/src/app.mm
@@ -90,10 +90,19 @@ static NSWindow *window = 0;
     NSString *vimPath = [[NSBundle mainBundle] pathForResource:@"nvim"
                                                         ofType:nil];
 
-    NSString *path = @"/bin/bash";
-    NSArray *args = @[@"-c", @"\"env\""];
+    const char *envShell = getenv("SHELL");
+    size_t envShellLength = envShell ? strlen(envShell) : 0;
+    NSString *shell = [[NSString alloc] initWithData:[NSData dataWithBytes:envShell length:envShellLength]
+                                            encoding:NSUTF8StringEncoding];
+
+    // Handle the case where `getenv` returns an empty string (but not NULL)
+    if (!shell.length) {
+        shell = @"/bin/bash";
+    }
+
+    NSArray *args = @[@"-l -c", @"\"env\""];
     NSTask *task = [NSTask new];
-    task.launchPath = path;
+    task.launchPath = shell;
     task.arguments = args;
     task.standardOutput = [NSPipe new];
     [task launch];

--- a/src/app.mm
+++ b/src/app.mm
@@ -1,5 +1,4 @@
 #include "vim.h"
-#include <syslog.h>
 
 #import "app.h"
 #import "view.h"
@@ -105,8 +104,7 @@ static NSWindow *window = 0;
     for (NSString *envVar in envVars) {
         NSArray *keyvalue = [envVar componentsSeparatedByString:@"="];
 
-        if (keyvalue.count != 2) {
-            syslog(LOG_WARNING, "string didn't match expected format: %s", envVar.UTF8String);
+        if (keyvalue.count < 2) {
             continue;
         }
 
@@ -115,9 +113,7 @@ static NSWindow *window = 0;
 
         char *old = getenv(key.UTF8String);
 
-        syslog(LOG_WARNING, "setting %s=%s", key.UTF8String, value.UTF8String);
-        syslog(LOG_WARNING, "(old value: %s)", old);
-        setenv(((NSString *)keyvalue[0]).UTF8String, ((NSString *)keyvalue[1]).UTF8String, 1);
+        setenv(key.UTF8String, value.UTF8String, 1);
     }
 
     /* Set both VIM and NVIM for now. TODO: Remove VIM when


### PR DESCRIPTION
This fixes issues related to incorrect environment variables, including errors with YouCompleteMe and Clighter using (or being unable to find) the correct version of Python (see #61).

The strategy used is to fork out a shell and have it run the "env" command, which outputs the environment variables to `stdout`. The output is then parsed and injected into Neovim.app's environment.