### PR TITLE
Experimental multiple window support

### DIFF
--- a/src/app.mm
+++ b/src/app.mm
@@ -1,6 +1,7 @@
 #include "vim.h"
 
 #import "app.h"
+#import "window.h"
 #import "view.h"
 #import "redraw.h"
 #import "font.h"
@@ -8,64 +9,11 @@
 extern int g_argc;
 extern char **g_argv;
 
-static Vim *vim = 0;
-static VimView *mainView = 0;
-static NSWindow *window = 0;
-
-@interface WindowDelegate : NSObject <NSWindowDelegate> {} @end
-@implementation WindowDelegate
-
-/* Override this so we can resize by whole cells, just like Terminal.app */
-- (NSSize)windowWillResize:(NSWindow *)sender toSize:(NSSize)frameSize
-{
-    NSRect frameRect = {CGPointZero, frameSize};
-
-    NSRect contentRect = [sender contentRectForFrameRect:frameRect];
-
-    CGSize cellSize = [mainView cellSizeInsideViewSize:contentRect.size];
-    [mainView requestResize:cellSize];
-
-    contentRect.size = [mainView viewSizeFromCellSize:cellSize];
-    frameRect = [sender frameRectForContentRect:contentRect];
-
-    return frameRect.size;
-}
-
-/* OS X doesn't send us a willResize event when leaving fullscreen mode, so: */
-- (void)windowDidExitFullScreen:(NSNotification *)notification
-{
-    [self windowWillResize:window toSize:[window frame].size];
-}
-
-- (void)windowDidBecomeKey:(NSNotification *)notification
-{
-    vim->vim_command("silent! doautoall <nomodeline> FocusGained");
-    vim->vim_command("checktime");
-}
-
-- (void)windowDidResignKey:(NSNotification *)notification
-{
-    vim->vim_command("silent! doautoall <nomodeline> FocusLost");
-}
-
-@end
+static VimWindow *activeWindow = 0;
 
 @implementation AppDelegate
 
-- (void)copyText { [mainView copyText]; }
-- (void)cutText { [mainView cutText]; }
-- (void)pasteText { [mainView pasteText]; }
 
-- (void)newTab { vim->vim_command("tabnew"); }
-- (void)nextTab { vim->vim_command("tabnext"); }
-- (void)prevTab { vim->vim_command("tabprev"); }
-- (void)closeTab { vim->vim_command("tabclose"); }
-- (void)saveBuffer { vim->vim_command("write"); }
-
-- (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)app
-{
-    return YES;
-}
 
 - (NSDictionary *)environmentFromLoginShell:(NSString *)shellPath
 {
@@ -133,6 +81,16 @@ static NSWindow *window = 0;
     }
 }
 
+- (void)newWindow
+{
+    activeWindow = [[[VimWindow alloc] init] retain];
+}
+
+- (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)app
+{
+    return YES;
+}
+
 - (void)applicationWillFinishLaunching:(NSNotification *)notification
 {
     [NSFontManager setFontManagerFactory:[VimFontManager class]];
@@ -144,20 +102,9 @@ static NSWindow *window = 0;
                                  @"fontName": @"Menlo",
                                  @"fontSize": @11.0}];
 
-    int width = [defaults integerForKey:@"width"];
-    int height = [defaults integerForKey:@"height"];
-
-    if (width <= 0 || height <= 0) {
-        width = 80;
-        height = 25;
-    }
-
-    NSString *vimDir = [[NSBundle mainBundle] resourcePath];
-    NSString *vimPath = [[NSBundle mainBundle] pathForResource:@"nvim"
-                                                        ofType:nil];
-
     [self loadLoginShellEnvironmentVariables];
 
+    NSString *vimDir = [[NSBundle mainBundle] resourcePath];
     /* Set both VIM and NVIM for now. TODO: Remove VIM when
        https://github.com/neovim/neovim/pull/1927 is merged */
     setenv("VIM", [vimDir UTF8String], 1);
@@ -177,125 +124,19 @@ static NSWindow *window = 0;
     setenv("LC_ALL", ss.str().c_str(), 1);
     setenv("LANG", ss.str().c_str(), 1);
 
-    vim = new Vim([vimPath UTF8String]);
-    vim->ui_attach(width, height, true);
-
-
-    mainView = [[VimView alloc] initWithCellSize:CGSizeMake(width, height)
-                                             vim:vim];
-
-    int style = NSTitledWindowMask |
-                NSClosableWindowMask |
-                NSMiniaturizableWindowMask |
-                NSResizableWindowMask;
-
-    window = [[[NSWindow alloc] initWithContentRect:[mainView frame]
-                                          styleMask:style
-                                            backing:NSBackingStoreBuffered
-                                              defer:YES] retain];
-
-    [window setContentView:mainView];
-    [window makeFirstResponder:mainView];
-    [window setDelegate:[[WindowDelegate alloc] init]];
-    [window makeKeyAndOrderFront:NSApp];
-    [window setCollectionBehavior:NSWindowCollectionBehaviorFullScreenPrimary];
-
-    [NSThread detachNewThreadSelector:@selector(vimThread:)
-                             toTarget:self
-                           withObject:nil];
+    [self newWindow];
 
     // Open files given on command-line
     for (int i=1; i<g_argc; i++) {
-        [mainView openFile:[NSString stringWithUTF8String:g_argv[i]]];
+        [activeWindow openFilename:[NSString stringWithUTF8String:g_argv[i]]];
     }
 }
 
 - (BOOL)application:(NSApplication *)app openFile:(NSString *)filename
 {
-    [mainView openFile:filename];
+    [activeWindow openFilename:filename];
     return YES;
 }
 
-/* This gets called on the main thread when Vim gives us a UI notification */
-- (void)notified:(const std::string &)note withData:(const msgpack::object &)update_o
-{
-    assert([NSThread isMainThread]);
-
-    if (note == "redraw") {
-
-        /* There must be a better way of finding out when the current buffer
-           has changed? Until we figure one out, update title every redraw. */
-        [self updateWindowTitle];
-        [mainView redraw:update_o];
-    }
-    else {
-        std::cout << "Unknown note " << note << "\n";
-    }
-}
-
-/* Set the window's title and “represented file” icon. */
-- (void)updateWindowTitle
-{
-    vim->vim_get_current_buffer().then([](Buffer buf) {
-        vim->buffer_get_name(buf).then([](std::string bufname) {
-            if (bufname.empty()) {
-                [window setTitle:@"Untitled"];
-                [window setRepresentedFilename:@""];
-                return;
-            }
-
-            NSString *nsBufname =
-                [NSString stringWithUTF8String:bufname.c_str()];
-
-            if ([[NSFileManager defaultManager] fileExistsAtPath:nsBufname]) {
-                [window setTitleWithRepresentedFilename:nsBufname];
-            }
-            else {
-                [window setTitleWithRepresentedFilename:nsBufname];
-                [window setRepresentedFilename:@""];
-            }
-        });
-    });
-}
-
-
-/* A selector to this method is posted to the main runloop in order to handle
-   an event from Vim on the main thread. */
-- (void)handleEvent:(id)idEvent
-{
-    assert([NSThread isMainThread]);
-
-    Event *event = (Event *)[(NSValue *)idEvent pointerValue];
-    RPC *rpc = event->rpc;
-
-    if (rpc) {
-        if (rpc->callback)
-            rpc->callback(rpc->get_value(), rpc->get_error());
-
-        delete rpc;
-    }
-
-    if (!event->note.empty()) {
-        [self notified:event->note withData:event->note_arg];
-    }
-}
-
-
-/* Vim thread. Waits for events from Vim, and schedules them to be handled on 
-   the main thread. */
-- (void)vimThread:(id)unused
-{
-    assert(![NSThread isMainThread]);
-
-    for (;;) {
-        Event event = vim->wait();
-
-        /* waitUntilDone needs to be YES here since we're accessing that
-           event from the other thread. */
-        [self performSelectorOnMainThread:@selector(handleEvent:)
-                               withObject:[NSValue valueWithPointer:&event]
-                            waitUntilDone:YES];
-    }
-}
 
 @end

--- a/src/menu.mm
+++ b/src/menu.mm
@@ -49,6 +49,7 @@ static NSMenu *makeFontMenu()
     [mi setSubmenu:sub];
 
     sub = [[NSMenu alloc] initWithTitle:@"File"];
+    [sub addItemWithTitle:@"New Window" action:@selector(newWindow) keyEquivalent:@"n"];
     [sub addItemWithTitle:@"New Tab" action:@selector(newTab) keyEquivalent:@"t"];
     [sub addItemWithTitle:@"Close Tab" action:@selector(closeTab) keyEquivalent:@"w"];
     [sub addItemWithTitle:@"Save Buffer" action:@selector(saveBuffer) keyEquivalent:@"s"];

--- a/src/window.h
+++ b/src/window.h
@@ -1,0 +1,8 @@
+#import <Cocoa/Cocoa.h>
+#import "view.h"
+
+@interface VimWindow : NSWindow <NSWindowDelegate>
+
+- (void)openFilename:(NSString *)file;
+
+@end

--- a/src/window.mm
+++ b/src/window.mm
@@ -1,0 +1,194 @@
+#include "vim.h"
+
+#import "window.h"
+#import "redraw.h"
+
+@implementation VimWindow
+{
+    Vim * vim;
+    VimView * mMainView;
+}
+
+/* Override this so we can resize by whole cells, just like Terminal.app */
+- (NSSize)windowWillResize:(NSWindow *)sender toSize:(NSSize)frameSize
+{
+    NSRect frameRect = {CGPointZero, frameSize};
+
+    NSRect contentRect = [sender contentRectForFrameRect:frameRect];
+
+    CGSize cellSize = [mMainView cellSizeInsideViewSize:contentRect.size];
+    [mMainView requestResize:cellSize];
+
+    contentRect.size = [mMainView viewSizeFromCellSize:cellSize];
+    frameRect = [sender frameRectForContentRect:contentRect];
+
+    return frameRect.size;
+}
+
+/* OS X doesn't send us a willResize event when leaving fullscreen mode, so: */
+- (void)windowDidExitFullScreen:(NSNotification *)notification
+{
+    [self windowWillResize:self toSize:[self frame].size];
+}
+
+- (void)windowDidBecomeKey:(NSNotification *)notification
+{
+    vim->vim_command("silent! doautoall <nomodeline> FocusGained");
+    vim->vim_command("checktime");
+}
+
+- (void)windowDidResignKey:(NSNotification *)notification
+{
+    vim->vim_command("silent! doautoall <nomodeline> FocusLost");
+}
+
+
+- (void)copyText { [mMainView copyText]; }
+- (void)cutText { [mMainView cutText]; }
+- (void)pasteText { [mMainView pasteText]; }
+
+- (void)newTab { vim->vim_command("tabnew"); }
+- (void)nextTab { vim->vim_command("tabnext"); }
+- (void)prevTab { vim->vim_command("tabprev"); }
+- (void)closeTab { vim->vim_command("tabclose"); }
+- (void)saveBuffer { vim->vim_command("write"); }
+
+
+- (id)init
+{
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    int width = [defaults integerForKey:@"width"];
+    int height = [defaults integerForKey:@"height"];
+
+    if (width <= 0 || height <= 0) {
+        width = 80;
+        height = 25;
+    }
+
+    NSString *vimPath = [[NSBundle mainBundle] pathForResource:@"nvim"
+                                                        ofType:nil];
+
+    vim = new Vim([vimPath UTF8String]);
+    vim->ui_attach(width, height, true);
+
+    mMainView = [[VimView alloc] initWithCellSize:CGSizeMake(width, height)
+                                             vim:vim];
+
+    int style = NSTitledWindowMask |
+                NSClosableWindowMask |
+                NSMiniaturizableWindowMask |
+                NSResizableWindowMask;
+
+    self = [super initWithContentRect:[mMainView frame]
+                                    styleMask:style
+                                    backing:NSBackingStoreBuffered
+                                    defer:YES];
+    if(!self) return nil;
+
+    [self setContentView:mMainView];
+    [self makeFirstResponder:mMainView];
+    [self setDelegate:self];
+    [self makeKeyAndOrderFront:NSApp];
+    [self setCollectionBehavior:NSWindowCollectionBehaviorFullScreenPrimary];
+
+    [NSThread detachNewThreadSelector:@selector(vimThread:)
+                             toTarget:self
+                           withObject:nil];
+
+    return self;
+}
+
+- (void)dealloc
+{
+    delete vim; vim = nil;
+    [super dealloc];
+}
+
+- (void)openFilename:(NSString *)file
+{
+        [mMainView openFile:file];
+}
+
+/* This gets called on the main thread when Vim gives us a UI notification */
+- (void)notified:(const std::string &)note withData:(const msgpack::object &)update_o
+{
+    assert([NSThread isMainThread]);
+
+    if (note == "redraw") {
+
+        /* There must be a better way of finding out when the current buffer
+           has changed? Until we figure one out, update title every redraw. */
+        [self updateWindowTitle];
+        [mMainView redraw:update_o];
+    }
+    else {
+        std::cout << "Unknown note " << note << "\n";
+    }
+}
+
+/* Set the window's title and “represented file” icon. */
+- (void)updateWindowTitle
+{
+    vim->vim_get_current_buffer().then([self](Buffer buf) {
+        vim->buffer_get_name(buf).then([self](std::string bufname) {
+            if (bufname.empty()) {
+                [self setTitle:@"Untitled"];
+                [self setRepresentedFilename:@""];
+                return;
+            }
+
+            NSString *nsBufname =
+                [NSString stringWithUTF8String:bufname.c_str()];
+
+            if ([[NSFileManager defaultManager] fileExistsAtPath:nsBufname]) {
+                [self setTitleWithRepresentedFilename:nsBufname];
+            }
+            else {
+                [self setTitleWithRepresentedFilename:nsBufname];
+                [self setRepresentedFilename:@""];
+            }
+        });
+    });
+}
+
+
+/* A selector to this method is posted to the main runloop in order to handle
+   an event from Vim on the main thread. */
+- (void)handleEvent:(id)idEvent
+{
+    assert([NSThread isMainThread]);
+
+    Event *event = (Event *)[(NSValue *)idEvent pointerValue];
+    RPC *rpc = event->rpc;
+
+    if (rpc) {
+        if (rpc->callback)
+            rpc->callback(rpc->get_value(), rpc->get_error());
+
+        delete rpc;
+    }
+
+    if (!event->note.empty()) {
+        [self notified:event->note withData:event->note_arg];
+    }
+}
+
+
+/* Vim thread. Waits for events from Vim, and schedules them to be handled on 
+   the main thread. */
+- (void)vimThread:(id)unused
+{
+    assert(![NSThread isMainThread]);
+
+    for (;;) {
+        Event event = vim->wait();
+
+        /* waitUntilDone needs to be YES here since we're accessing that
+           event from the other thread. */
+        [self performSelectorOnMainThread:@selector(handleEvent:)
+                               withObject:[NSValue valueWithPointer:&event]
+                            waitUntilDone:YES];
+    }
+}
+
+@end


### PR DESCRIPTION
A first pass at adding multiple window support to neovim.app. See #23.

- Adds window.mm to manage each window using a VimWindow
- Each window owns a Vim object and a VimView