### PR TITLE
Stop Neovim.app from exiting when one process quits

### DIFF
--- a/src/client.cc
+++ b/src/client.cc
@@ -106,8 +106,9 @@ again:
         );
 
         if (sz == 0) {
-            std::cerr << "No more data\n";
-            exit(-1);
+            std::cerr << "No more data, closing window\n";
+            Event r = {0, std::string("neovim.app.nodata")};
+            return r;
         }
 
         if (sz < 0) {

--- a/src/window.mm
+++ b/src/window.mm
@@ -183,6 +183,13 @@
     for (;;) {
         Event event = vim->wait();
 
+        /* The vim client closed our pipe, so it must have exited. */
+        if(!event.note.empty() && event.note == "neovim.app.nodata") {
+            [self performSelectorOnMainThread:@selector(close)
+                                   withObject:nil waitUntilDone:YES];
+            return;
+        }
+
         /* waitUntilDone needs to be YES here since we're accessing that
            event from the other thread. */
         [self performSelectorOnMainThread:@selector(handleEvent:)


### PR DESCRIPTION
When the forked neovim instance exits, emit a message to close the window. This still causes a SIGPIPE, which exits the app, so we also have to ignore SIGPIPE.

Fixes #79