### PR TITLE
Integration with Vim's menu system

### DIFF
--- a/res/nvimrc
+++ b/res/nvimrc
@@ -7,3 +7,93 @@ nnoremap <C-6> <C-^>
 function! MacSetFont(name, size)
     call rpcnotify(1, "neovim.app.setfont", a:name, a:size)
 endfunction
+
+function! MacIncreaseFontSize()
+    call rpcnotify(1, "neovim.app.larger")
+endfunction
+
+function! MacDecreaseFontSize()
+    call rpcnotify(1, "neovim.app.smaller")
+endfunction
+
+function! MacShowFontSelector()
+    call rpcnotify(1, "neovim.app.showfonts")
+endfunction
+
+function! MacToggleFullScreen()
+    call rpcnotify(1, "neovim.app.fullscreen")
+endfunction
+
+function! MacMenu(name, keyEquivalent)
+    call rpcnotify(1, "neovim.app.menu", a:name, a:keyEquivalent)
+endfunction
+
+function! MacNewWindow()
+    call rpcnotify(1, "neovim.app.window")
+endfunction
+
+function! MacCloseTabOrWindow()
+    try
+        tabclose
+    catch
+         q
+    endtry
+endfunction
+
+" First, load the default menus
+runtime menu.vim
+
+" Remove menu commands that rely on :browse
+aunmenu File.Open\.\.\.
+aunmenu File.Split-Open\.\.\.
+aunmenu File.Open\ Tab\.\.\.
+aunmenu File.Save\ As\.\.\.
+aunmenu File.Split\ Diff\ with\.\.\.
+aunmenu File.Split\ Patched\ By\.\.\.
+
+" Exit doesn't belong in the File menu
+aunmenu &File.Save-Exit
+aunmenu &File.Exit
+
+" Add Mac font options
+anoremenu &Edit.-nvapp1- :
+anoremenu &Edit.Increase\ Font\ Size :call MacIncreaseFontSize()<CR>
+anoremenu &Edit.Decrease\ Font\ Size :call MacDecreaseFontSize()<CR>
+anoremenu &Edit.Show\ Fonts :call MacShowFontSelector()<CR>
+
+" Add Mac tab controls
+anoremenu .310 &File.New\ Window :call MacNewWindow()<CR>
+anoremenu .336 &Window.New\ Tab :tabnew<CR>
+anoremenu .337 &Window.Next\ Tab :tabnext<CR>
+anoremenu .337 &Window.Previous\ Tab :tabprev<CR>
+anoremenu .337 &Window.Close\ Tab :call MacCloseTabOrWindow()<CR>
+anoremenu .337 &Window.Close\ Other\ Tabs :tabonly<CR>
+anoremenu .338 &Window.-nvapp2- :
+
+" Add Mac fullscreen control
+anoremenu .900 &Window.-nvapp3- :
+anoremenu .900 &Window.Toggle\ Full\ Screen :call MacToggleFullScreen()<CR>
+
+" Assign Cmd-key shortcuts
+call MacMenu("File.New Window", "T-n")
+call MacMenu("File.Save", "T-s")
+call MacMenu("File.Open...", "T-o")
+call MacMenu("File.Print", "T-p")
+
+call MacMenu("Edit.Undo", "T-z")
+call MacMenu("Edit.Redo", "T-S-z")
+call MacMenu("Edit.Cut", "T-x")
+call MacMenu("Edit.Copy", "T-c")
+call MacMenu("Edit.Paste", "T-v")
+
+call MacMenu("Edit.Increase Font Size", "T-+")
+call MacMenu("Edit.Decrease Font Size", "T--")
+
+call MacMenu("Window.New Tab", "T-t")
+call MacMenu("Window.Next Tab", "T-}")
+call MacMenu("Window.Previous Tab", "T-{")
+call MacMenu("Window.Close Tab", "T-w")
+call MacMenu("Window.Close Other Tabs", "T-S-w")
+
+call MacMenu("Window.Toggle Full Screen", "T-f")
+

--- a/src/app.h
+++ b/src/app.h
@@ -1,8 +1,7 @@
 #import <Cocoa/Cocoa.h>
 
 @interface AppDelegate : NSResponder <NSApplicationDelegate> {}
-@end
 
-@interface AppDelegate (Menus)
-    -(void) initMenu;
+- (void) newWindow;
+
 @end

--- a/src/app.mm
+++ b/src/app.mm
@@ -108,7 +108,6 @@ void ignore_sigpipe(void)
 - (void)applicationWillFinishLaunching:(NSNotification *)notification
 {
     [NSFontManager setFontManagerFactory:[VimFontManager class]];
-    [self initMenu];
 
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     [defaults registerDefaults:@{@"width": @80,

--- a/src/menu.h
+++ b/src/menu.h
@@ -1,0 +1,11 @@
+
+@interface VimView (Menus)
+    - (void) initMenu;
+    - (void) updateMenu;
+    - (void) showMenu;
+    - (void) customizeMenu:(const msgpack::object &)update_o;
+
+    - (void) increaseFontSize;
+    - (void) decreaseFontSize;
+    - (void) showFontSelector;
+@end

--- a/src/menu.mm
+++ b/src/menu.mm
@@ -1,4 +1,48 @@
-#include "app.h"
+#include "vim.h"
+#include "vimutils.h"
+
+#import "app.h"
+#import "window.h"
+#import "menu.h"
+
+#include <iostream>
+
+struct MenuInfo {
+    std::string keyEquivalent;
+    unsigned modifierMask;
+};
+
+std::map<std::string, MenuInfo> infoMap;
+
+MenuInfo parseKeyEquivalent(std::string str)
+{
+    std::stringstream ss(str);
+
+    MenuInfo info;
+
+    info.modifierMask = 0;
+
+    char last;
+    for (;;) {
+        char ch = ss.get();
+        if (ss.eof())
+            break;
+
+        if (ch == '-' && last != '-') {
+            switch (last) {
+                case 'C': info.modifierMask |= NSControlKeyMask; break;
+                case 'T': info.modifierMask |= NSCommandKeyMask; break;
+                case 'M': info.modifierMask |= NSAlternateKeyMask; break;
+                case 'S': info.modifierMask |= NSShiftKeyMask; break;
+                default: throw "Bad modifier";
+            }
+        }
+        last = ch;
+    }
+
+    info.keyEquivalent = str.substr(str.size() - 1);
+    return info;
+}
 
 /* The Cocoa font menu contains stuff we don't want, like color, ligatures,
     etc., so make our own font menu (with texas hold 'em and loose women) and
@@ -33,55 +77,212 @@ static NSMenu *makeFontMenu()
     return sub;
 }
 
-@implementation AppDelegate (Menus)
+NSString *menuPath(NSMenuItem *item) {
+    NSString *name = [item title];
+    item = [item parentItem];
+    while (item) {
+        name = [@"." stringByAppendingString:name];
+        name = [[item title] stringByAppendingString:name];
+        item = [item parentItem];
+    }
+    return name;
+}
 
-/* Create our anaemic menu bar. TODO: Ask Vim for its menus */
+@implementation VimView (Menus)
+
 - (void) initMenu
 {
-    NSMenu *menu, *sub;
-    NSMenuItem *mi;
+    mFontMenu = makeFontMenu();
+}
 
-    menu = [[NSMenu alloc] initWithTitle: @""];
+- (void) handleVimMenuItem:(id)sender
+{
+    NSMenuItem *item = (NSMenuItem *)sender;
+    NSString *name = menuPath(item);
 
-    sub = [[NSMenu alloc] initWithTitle:@"Neovim"];
-    [sub addItemWithTitle:@"Quit" action:@selector(terminate:) keyEquivalent:@"q"];
-    mi = [menu addItemWithTitle:@"" action:nil keyEquivalent:@""];
-    [mi setSubmenu:sub];
+    std::stringstream cmd;
+    cmd << "emenu ";
+    cmd << [name UTF8String];
+    mVim->vim_command(cmd.str());
+}
 
-    sub = [[NSMenu alloc] initWithTitle:@"File"];
-    [sub addItemWithTitle:@"New Window" action:@selector(newWindow) keyEquivalent:@"n"];
-    [sub addItemWithTitle:@"New Tab" action:@selector(newTab) keyEquivalent:@"t"];
-    [sub addItemWithTitle:@"Close" action:@selector(closeTabOrWindow) keyEquivalent:@"w"];
-    [sub addItemWithTitle:@"Save Buffer" action:@selector(saveBuffer) keyEquivalent:@"s"];
-    mi = [menu addItemWithTitle:@"" action:nil keyEquivalent:@""];
-    [mi setSubmenu:sub];
+- (void) customizeMenu:(const msgpack::object &)update_o
+{
+    std::vector<msgpack::object> args = update_o.convert();
 
-    sub = [[NSMenu alloc] initWithTitle:@"Edit"];
-    [sub addItemWithTitle:@"Cut" action:@selector(cutText) keyEquivalent:@"x"];
-    [sub addItemWithTitle:@"Copy" action:@selector(copyText) keyEquivalent:@"c"];
-    [sub addItemWithTitle:@"Paste" action:@selector(pasteText) keyEquivalent:@"v"];
-    [sub addItemWithTitle:@"Select All" action:@selector(selectAll) keyEquivalent:@"a"];
-    mi = [menu addItemWithTitle:@"" action:nil keyEquivalent:@""];
-    [mi setSubmenu:sub];
+    if (args.size() != 2) {
+        throw "MacMenu expects 2 arguments (name, keyEquivalent)";
+    }
 
-    mi = [menu addItemWithTitle:@"" action:nil keyEquivalent:@""];
-    sub = makeFontMenu();
-    [mi setSubmenu:sub];
+    std::string path = args[0].convert();
+    std::string keyEquivalentStr = args[1].convert();
 
-    sub = [[NSMenu alloc] initWithTitle:@"View"];
-    mi = [sub addItemWithTitle:@"Toggle Full Screen" action:@selector(toggleFullScreen:) keyEquivalent:@"f"];
-    [mi setKeyEquivalentModifierMask: NSControlKeyMask | NSCommandKeyMask];
-    mi = [menu addItemWithTitle:@"" action:nil keyEquivalent:@""];
-    [mi setSubmenu:sub];
+    MenuInfo menuInfo = parseKeyEquivalent(keyEquivalentStr);
+    infoMap[path] = menuInfo;
+    [self updateMenu];
+}
 
-    sub = [[NSMenu alloc] initWithTitle:@"Window"];
-    [sub addItemWithTitle:@"Show Previous Tab" action:@selector(prevTab) keyEquivalent:@"{"];
-    [sub addItemWithTitle:@"Show Next Tab" action:@selector(nextTab) keyEquivalent:@"}"];
-    mi = [menu addItemWithTitle:@"" action:nil keyEquivalent:@""];
-    [mi setSubmenu:sub];
+- (void) updateMenu
+{
+    mVim->vim_command_output("silent menu").then([self](std::string string) {
+        [self createMenuFromVimString:string];
+    });
+}
 
+- (void) showAbout
+{
+    mVim->vim_command("intro");
+}
 
-    [NSApp setMainMenu:menu];
+- (void) executeMenuItem:(NSMenuItem *)item
+{
+    id target = [item target];
+    SEL action = [item action];
+
+    [target performSelector:action withObject:item];
+}
+
+- (void) increaseFontSize
+{
+    [self executeMenuItem:[mFontMenu itemWithTitle:@"Larger"]];
+}
+
+- (void) decreaseFontSize
+{
+    [self executeMenuItem:[mFontMenu itemWithTitle:@"Smaller"]];
+}
+
+- (void) showFontSelector
+{
+    [self executeMenuItem:[mFontMenu itemWithTitle:@"Show Fonts"]];
+}
+
+- (void) createMenuFromVimString:(const std::string &)string {
+
+    static int g_counter = 0;
+    int inst = g_counter++;
+
+    [mPopupMenu release];
+    mPopupMenu = nil;
+
+    [mMenuBar release];
+    mMenuBar = [[NSMenu alloc] initWithTitle: @""];
+
+    // Make app menu
+    NSMenu *app = [[NSMenu alloc] initWithTitle:@"Neovim"];
+    [app addItemWithTitle:@"About Neovim" action:@selector(showAbout) keyEquivalent:@""];
+    [app addItem:[NSMenuItem separatorItem]];
+    [app addItemWithTitle:@"Quit" action:@selector(terminate:) keyEquivalent:@"q"];
+    NSMenuItem *appItem = [mMenuBar addItemWithTitle:@"" action:nil keyEquivalent:@""];
+    [appItem setSubmenu:app];
+
+    std::map<int, NSMenuItem *> treeMap;
+
+    std::istringstream stream(string);
+    std::string line;
+    while(std::getline(stream, line)) {
+
+        if (line.empty())
+            continue;
+
+        if (line[0] == '-')
+            continue;
+
+        std::stringstream ss(line);
+
+        int indent = 0;
+        while(ss.get() == 32)
+            indent += 1;
+        ss.unget();
+
+        std::string priority_or_mode;
+        ss >> priority_or_mode >> std::ws;
+
+        char key = priority_or_mode[0];
+        if ('0' <= key && key <= '9') {
+            std::stringstream priority_ss(priority_or_mode);
+            int priority;
+            priority_ss >> priority;
+
+            std::string caption;
+            std::getline(ss, caption);
+
+            size_t tab_pos = caption.find("^I");
+            if (tab_pos != std::string::npos) {
+                caption = caption.substr(0, tab_pos);
+            }
+
+            NSString *nsCaption = [NSString stringWithUTF8String:caption.c_str()];
+            nsCaption = [nsCaption stringByReplacingOccurrencesOfString:@"&" withString:@""];
+
+            if (indent == 0) {
+                NSMenu *menu = [[NSMenu alloc] initWithTitle:nsCaption];
+                NSMenuItem *heading = [[NSMenuItem alloc] initWithTitle:nsCaption action:nil keyEquivalent:@""];
+
+                if (mPopupMenu) {
+                    [mMenuBar addItem:heading];
+                }
+                else {
+                    mPopupMenu = heading;
+                }
+
+                [heading setSubmenu:menu];
+
+                treeMap[2] = heading;
+            }
+            else {
+                NSMenuItem *parentItem = treeMap[indent];
+                if (!parentItem) {
+                    std::cerr << "Menu is weird\n";
+                    std::cerr << "no parent for indent level " << indent << "\n";
+
+                    for (auto x: treeMap) {
+                    std::cerr << x.first << " :: " << x.second << "\n";
+                    }
+                    continue;
+                }
+
+                NSMenu *parent = [parentItem submenu];
+                if (!parent) {
+                    parent = [[NSMenu alloc] initWithTitle:nsCaption];
+                    [parentItem setSubmenu:parent];
+                }
+
+                NSMenuItem *item;
+
+                if (caption[0] == '-') {
+                    item = [NSMenuItem separatorItem];
+                    [parent addItem:item];
+                }
+                else {
+                    item = [parent addItemWithTitle:nsCaption
+                                             action:@selector(handleVimMenuItem:)
+                                      keyEquivalent:@""];
+                }
+
+                treeMap[indent + 2] = item;
+
+                NSString *nsPath = menuPath(item);
+                std::string path = [nsPath UTF8String];
+                auto it = infoMap.find(path);
+                if (it != infoMap.end()) {
+                    const MenuInfo &info = it->second;
+                    NSString *keyEquivalent =
+                        [NSString stringWithUTF8String:info.keyEquivalent.c_str()];
+                    [item setKeyEquivalent:keyEquivalent];
+                    [item setKeyEquivalentModifierMask:info.modifierMask];
+                }
+            }
+        }
+    }
+
+    if ([[self window] isKeyWindow])
+        [self showMenu];
+}
+
+-(void)showMenu
+{
+    [NSApp setMainMenu:mMenuBar];
 }
 
 @end

--- a/src/redraw.gperf
+++ b/src/redraw.gperf
@@ -5,6 +5,7 @@
         {
             put,
             cursor_goto,
+            update_menu,
             clear,
             eol_clear,
             highlight_set,
@@ -32,6 +33,7 @@ struct RedrawAction
 %%
 put,               RedrawCode::put
 cursor_goto,       RedrawCode::cursor_goto
+update_menu,       RedrawCode::update_menu
 clear,             RedrawCode::clear
 eol_clear,         RedrawCode::eol_clear
 highlight_set,     RedrawCode::highlight_set

--- a/src/redraw.mm
+++ b/src/redraw.mm
@@ -11,6 +11,7 @@
 #import <CoreFoundation/CoreFoundation.h>
 #import "view.h"
 #import "graphics.h"
+#import "menu.h"
 
 static const bool debug = false;
 
@@ -27,6 +28,8 @@ using msgpack::object;
     [NSGraphicsContext setCurrentContext:[NSGraphicsContext
         graphicsContextWithGraphicsPort:(void *)mCanvasContext
         flipped:NO]];
+
+    mMenuNeedsUpdate = false;
 
     try
     {
@@ -64,6 +67,10 @@ using msgpack::object;
     }
 
     [NSGraphicsContext restoreGraphicsState];
+
+    if (mMenuNeedsUpdate) {
+        [self updateMenu];
+    }
 }
 
 - (void) doAction:(RedrawCode::Enum)code withItem:(const object &)item_o
@@ -245,6 +252,12 @@ using msgpack::object;
                 [self setNeedsDisplay:YES];
             }
 
+            break;
+        }
+
+        case RedrawCode::update_menu:
+        {
+            mMenuNeedsUpdate = true;
             break;
         }
 

--- a/src/view.h
+++ b/src/view.h
@@ -28,6 +28,11 @@ class Vim;
     NSFont *mBoldFont;
     NSFont *mItalicFont;
     NSFont *mBoldItalicFont;
+
+    NSMenu *mMenuBar;
+    NSMenuItem *mPopupMenu;
+    NSMenu *mFontMenu;
+    bool mMenuNeedsUpdate;
 }
 
 - (void)cutText;

--- a/src/view.mm
+++ b/src/view.mm
@@ -7,6 +7,7 @@
 #import "input.h"
 #import "graphics.h"
 #import "vimutils.h"
+#import "menu.h"
 
 @implementation VimView
 
@@ -50,6 +51,8 @@
 
         [self registerForDraggedTypes:[NSArray arrayWithObjects: NSFilenamesPboardType, nil]];
     }
+
+    [self initMenu];
 
     return self;
 }

--- a/src/vimutils.h
+++ b/src/vimutils.h
@@ -6,5 +6,6 @@
 class Vim;
 
 typedef std::function<void()> VoidFn;
+typedef std::function<void(VoidFn)> AsyncCallback;
 
 void with_option(Vim *vim, std::string option, VoidFn cb);


### PR DESCRIPTION
**Functionality:**
Vim menus are implemented in the Mac menu bar. Bar updates when
menus change.

VimScript APIs have been added for Mac-specific features which
until now were hard-coded into the menu:

    MacIncreaseFontSize
    MacDecreaseFontSize
    MacShowFontSelector
    MacToggleFullScreen
    MacNewWindow
    MacCloseTabOrWindow

Mac "Key Equivalents" can be set with:

    MacMenu

**Issues:**

Key equivalents are specified in pseudo-Vim notation, parsed in
parseKeyEquivalent. This is still incomplete and cannot parse
much of Vim's notation.

Each Vim instance has its own menu bar, so we should update the
main menu bar when switching windows.