### PR TITLE
Fixed dragging files into window when :set nohidden is on

### DIFF
--- a/res/nvimrc
+++ b/res/nvimrc
@@ -57,7 +57,6 @@ function! MacCloseTabOrWindow()
 endfunction
 
 function! MacOpenFileInBufferOrNewTab(filename)
-    echom a:filename
     if expand("%:p") == "" && &modified == 0
         execute "edit " . a:filename
     else

--- a/res/nvimrc
+++ b/res/nvimrc
@@ -56,6 +56,15 @@ function! MacCloseTabOrWindow()
     endtry
 endfunction
 
+function! MacOpenFileInBufferOrNewTab(filename)
+    echom a:filename
+    if expand("%:p") == "" && &modified == 0
+        execute "edit " . a:filename
+    else
+        execute "tabedit " . a:filename
+    endif
+endfunction
+
 " First, load the default menus
 runtime menu.vim
 

--- a/src/view.mm
+++ b/src/view.mm
@@ -265,16 +265,25 @@
 
     filename = [nsFilename UTF8String];
 
-    ss << "e ";
+    ss << "call MacOpenFileInBufferOrNewTab(\" ";
 
     /* We don't want Vim to try and interpret any part of the filename, and
        there's no documentation of what needs escaping, so escape every byte
-       of it. */
+       of it. 
+     
+       Characters need to be doubly escaped when passing it through exec.  */
     for (char ch : filename) {
-        ss << '\\' << ch;
+        ss << "\\\\" << ch;
     }
+    ss << "\")";
 
-    mVim->vim_command(ss.str());
+    mVim->vim_command(ss.str()).then([self](msgpack::object err){
+            if (err.is_nil()) return;
+
+            std::string errmsg = err.via.array.ptr[1].convert();
+            errmsg = errmsg.substr(errmsg.find(":")+1);
+            mVim->vim_report_error(errmsg); 
+        });
 }
 
 - (NSDragOperation)draggingEntered:(id <NSDraggingInfo>)sender

--- a/src/view.mm
+++ b/src/view.mm
@@ -265,17 +265,22 @@
 
     filename = [nsFilename UTF8String];
 
-    ss << "call MacOpenFileInBufferOrNewTab(\" ";
+    ss << "call MacOpenFileInBufferOrNewTab(\"";
 
     /* We don't want Vim to try and interpret any part of the filename, and
        there's no documentation of what needs escaping, so escape every byte
-       of it. 
+       of it.  
      
-       Characters need to be doubly escaped when passing it through exec.  */
+       Characters need to be doubly escaped when passing it through exec.  
+       Quotes need a third '\' */
     for (char ch : filename) {
+        if (ch == '"') 
+            ss << "\\";
         ss << "\\\\" << ch;
     }
     ss << "\")";
+
+    std::cout << "Sending: " << ss.str() << "\n";
 
     mVim->vim_command(ss.str()).then([self](msgpack::object err){
             if (err.is_nil()) return;


### PR DESCRIPTION
Dragging files into a window will open in the same buffer if it is an unnamed buffer that is unmodified. All other cases it will open the dragged files into new tabs.

If you drag multiple files in, those will all be opened in tabs.  Any errors that may come from opening a file (that for example one does not have read access to) are displayed via `vim_report_error`

I chose to add a function to the nvimrc to do what needed to do the opening of the file so that the command passed would not be an inline function. 

Also, one thing to note calling execute to edit/tabedit/save/etc.. a file it needs to be escaped twice. 