### PR TITLE
Re-Sourcing .nvimrc after attaching

### DIFF
--- a/src/window.mm
+++ b/src/window.mm
@@ -87,6 +87,13 @@
     mVim = new Vim([vimPath UTF8String], args);
     mVim->ui_attach(width, height, true);
 
+    /* Reload .nvimrc after connecting to get any settings requiring
+       gui_running to be re-evaluated as true.
+       This should be removed after an implementation similar to
+       https://github.com/neovim/python-client/issues/106
+       is done. */
+    mVim->vim_command("so $MYVIMRC");
+
     mMainView = [[VimView alloc] initWithCellSize:CGSizeMake(width, height)
                                               vim:mVim];
 


### PR DESCRIPTION
Re-Sourciing .nvimrc after attaching to the created process. This way anything that does a `has(gui_running)` will be set. 

Fixes the issue in #130 