### PR TITLE
Hide the mouse cursor when typing in the window.

### DIFF
--- a/src/input.mm
+++ b/src/input.mm
@@ -18,6 +18,8 @@
     std::string raws = raw.str();
     if (raws.size())
         [self vimInput:raws];
+
+    [NSCursor setHiddenUntilMouseMoves:YES];
 }
 
 - (void)mouseEvent:(NSEvent *)event drag:(BOOL)drag type:(const char *)type


### PR DESCRIPTION
Hides the mouse cursor when typing in the window. The cursor reappears when the mouse is moved. This seems to be the behavior that most OSX apps have including MacVim, Terminal, and even Chrome. 

This is in regards to Issue #136 