### PR TITLE
Show modified bufffers and prompt to save when closing window with modified buffers

### DIFF
--- a/res/nvimrc
+++ b/res/nvimrc
@@ -61,19 +61,25 @@ function! MacUpdateTitle()
 endfunction
 
 function! MacBufChanged()
-    call rpcnotify(1, "neovim.app.bufchanged", &modified)
+    let anyModified = s:mac_get_modified_buffers() != []
+    call rpcnotify(1, "neovim.app.bufchanged", anyModified)
 endfunction
 
 function! MacGetDirtyBuffers()
-    let allBufs      = range(1, bufnr('$'))
-    let activeBufs   = filter(allBufs, 'buflisted(v:val)')
     let dirtyBuffers = ""
 
-    for x in filter(activeBufs, 'getbufvar(v:val, "&modified")')
+    for x in s:mac_get_modified_buffers()
        let dirtyBuffers .= x . "\n" . bufname(x) . "\n"
     endfor
 
     silent! echo dirtyBuffers
+endfunction
+
+function! s:mac_get_modified_buffers()
+    let allBufs      = range(1, bufnr('$'))
+    let activeBufs   = filter(allBufs, 'buflisted(v:val)')
+
+    return filter(activeBufs, 'getbufvar(v:val, "&modified")')
 endfunction
 
 " First, load the default menus

--- a/res/nvimrc
+++ b/res/nvimrc
@@ -40,6 +40,10 @@ function! MacCloseTabOrWindow()
     endtry
 endfunction
 
+function! NeovimAppBufChanged()
+    call rpcnotify(1, "neovim.app.bufchanged", &modified)
+endfunction
+
 " First, load the default menus
 runtime menu.vim
 
@@ -97,3 +101,5 @@ call MacMenu("Window.Close Other Tabs", "T-S-w")
 
 call MacMenu("Window.Toggle Full Screen", "T-f")
 
+" Update modified status on all events that could cause a change
+autocmd TextChanged,BufWritePost,InsertLeave,BufEnter,BufLeave * call NeovimAppBufChanged()

--- a/res/nvimrc
+++ b/res/nvimrc
@@ -52,7 +52,7 @@ function! MacCloseTabOrWindow()
     try
         tabclose
     catch
-         q
+         call rpcnotify(1, "neovim.app.closeTabOrWindow")
     endtry
 endfunction
 
@@ -60,9 +60,20 @@ function! MacUpdateTitle()
     call rpcnotify(1, "neovim.app.updateTitle")
 endfunction
 
-
 function! MacBufChanged()
     call rpcnotify(1, "neovim.app.bufchanged", &modified)
+endfunction
+
+function! MacGetDirtyBuffers()
+    let allBufs      = range(1, bufnr('$'))
+    let activeBufs   = filter(allBufs, 'buflisted(v:val)')
+    let dirtyBuffers = ""
+
+    for x in filter(activeBufs, 'getbufvar(v:val, "&modified")')
+       let dirtyBuffers .= x . "\n" . bufname(x) . "\n"
+    endfor
+
+    silent! echo dirtyBuffers
 endfunction
 
 " First, load the default menus
@@ -132,4 +143,4 @@ call MacMenu("Window.Toggle Full Screen", "T-f")
 autocmd BufEnter,BufFilePost,BufWritePost * call MacUpdateTitle()
 
 " Update modified status on all events that could cause a change
-autocmd TextChanged,BufWritePost,InsertLeave,BufEnter,BufLeave * call MacBufChanged()
+autocmd TextChanged,BufWritePost,InsertEnter,InsertLeave,BufEnter,BufLeave * call MacBufChanged()

--- a/src/app.mm
+++ b/src/app.mm
@@ -105,6 +105,15 @@ void ignore_sigpipe(void)
     activeWindow = [[[VimWindow alloc] initWithArgs:args] retain];
 }
 
+- (NSApplicationTerminateReply)applicationShouldTerminate:(NSApplication *)sender
+{
+    if ([activeWindow isVisible]) {
+        [activeWindow promptBeforeClosingWindow];
+        return NSTerminateCancel;
+    }
+
+    return NSTerminateNow;
+}
 - (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)app
 {
     return YES;

--- a/src/input.mm
+++ b/src/input.mm
@@ -19,6 +19,9 @@
     if (raws.size())
         [self vimInput:raws];
 
+    if (mInsertMode)
+        [[self window] setDocumentEdited:YES];
+
     [NSCursor setHiddenUntilMouseMoves:YES];
 }
 

--- a/src/input.mm
+++ b/src/input.mm
@@ -19,9 +19,6 @@
     if (raws.size())
         [self vimInput:raws];
 
-    if (mInsertMode)
-        [[self window] setDocumentEdited:YES];
-
     [NSCursor setHiddenUntilMouseMoves:YES];
 }
 
@@ -87,6 +84,9 @@
 /* Send an input string to Vim. */
 - (void)vimInput:(const std::string &)input
 {
+    if (mInsertMode)
+        [[self window] setDocumentEdited:YES];
+
     mVim->vim_input(input);
 }
 

--- a/src/redraw.mm
+++ b/src/redraw.mm
@@ -1,4 +1,5 @@
 #include <cassert>
+
 #include <iostream>
 #include <string>
 #include <vector>

--- a/src/window.h
+++ b/src/window.h
@@ -5,5 +5,6 @@
 
 - (void)openFilename:(NSString *)file;
 - (id)initWithArgs:(const std::vector<char *> &)args;
+- (void)promptBeforeClosingWindow;
 
 @end

--- a/src/window.mm
+++ b/src/window.mm
@@ -189,6 +189,10 @@
             mVim->vim_report_error(msg);
         }
     }
+    else if (note ==  "neovim.app.bufchanged") {
+        int isModified = update_o.via.array.ptr[0].convert();
+        [self setDocumentEdited:isModified?YES:NO];
+    }
     else {
         std::cout << "Unknown note " << note << "\n";
     }

--- a/src/window.mm
+++ b/src/window.mm
@@ -12,6 +12,14 @@
     NSThread *mVimThread;
 }
 
+typedef NS_ENUM(NSInteger, CloseAction) {
+    CloseActionSave,
+    CloseActionDontSave,
+    CloseActionSaveAll,
+    CloseActionDiscardAll,
+    CloseActionCancel
+};
+
 /* Override this so we can resize by whole cells, just like Terminal.app */
 - (NSSize)windowWillResize:(NSWindow *)sender toSize:(NSSize)frameSize
 {
@@ -26,6 +34,133 @@
     frameRect = [sender frameRectForContentRect:contentRect];
 
     return frameRect.size;
+}
+
+- (BOOL)windowShouldClose:(id)sender
+{
+    [self promptBeforeClosingWindow];
+    return NO;
+}
+
+- (void)promptBeforeClosingWindow
+{
+    mVim->vim_command_output("call MacGetDirtyBuffers()")
+        .then([self](std::string dirtyBufs){
+            /* A list of modified/dirty buffers are returned with the buffer
+               number and name. All seperated by newlines */
+            if (dirtyBufs.length() <= 1)
+                /* All good. Nothing to save */
+                [self close];
+
+            /* A newline is at the beginning of the string */
+            dirtyBufs.erase(dirtyBufs.begin());
+
+            std::stringstream saveCmd;
+            std::stringstream ss(dirtyBufs);
+
+            BOOL shouldClose  = YES;
+            BOOL isSaveAll    = NO;
+            int numBuffers = std::count(dirtyBufs.begin(), dirtyBufs.end(), '\n') / 2;
+            for (int x = numBuffers; x > 0; x--) {
+                NSModalResponse resp;
+                BOOL saveThis = NO;
+                std::string bufnr, filename;
+
+                std::getline(ss, bufnr, '\n');
+                std::getline(ss, filename, '\n');
+
+                if (!isSaveAll) {
+                    resp = [self alertSaveFileBeforeClose:filename saveMultiple:(x == 1) ? NO : YES];
+                    if (resp == CloseActionSave)
+                        saveThis = YES;
+                    else if(resp == CloseActionDontSave)
+                        continue;
+                    else if(resp == CloseActionSaveAll)
+                        isSaveAll = YES;
+                    else if(resp == CloseActionDiscardAll)
+                        break;
+                    else {
+                        shouldClose = NO;
+                        break;
+                    }
+                }
+
+                if (isSaveAll || saveThis) {
+                    std::string newFilename = "";
+                    saveCmd << "b" << bufnr;
+                    if (filename == "") {
+                        /* If the buffer has no name,  prompt for it to be saved.
+                           If the action is canceled, the loop is ended and the
+                           unnamed buffer is not saved. All other buffers that
+                           have been set to save prior to this point will be saved. */
+                        NSURL *file = [mMainView showFileSaveDialog];
+                        if (file == nil) {
+                            shouldClose = NO;
+                            break;
+                        }
+                        newFilename = [self escapeVimCharsInString:[[file path] UTF8String]];
+                    }
+                    saveCmd << " | w! " << newFilename << " | ";
+                }
+            }
+
+            if (shouldClose)
+                saveCmd << "qa!";
+
+            /* Perform the saves. and Exit if specified. Don't exit if there is an error */
+            mVim->vim_command(saveCmd.str())
+                .then([self](msgpack::object error){
+                    if (error.is_nil())
+                        return;
+
+                    std::string errmsg = error.via.array.ptr[1].convert();
+                    errmsg = errmsg.substr(errmsg.find(":")+1);
+                    mVim->vim_report_error(errmsg);
+                });
+        });
+}
+
+- (CloseAction)alertSaveFileBeforeClose:(std::string)fileName saveMultiple:(bool)isMulti
+{
+    NSString *msgText = @"";
+    int response=-1;
+
+    if (isMulti)
+        msgText = [msgText stringByAppendingString:@"There are several documents with unsaved changes. "];
+
+    if (fileName == "")
+        fileName = "Untitled";
+
+    msgText = [msgText stringByAppendingFormat:@"Do you want to save the changes you made in the document \"%s\"?",
+            fileName.c_str()];
+
+    NSAlert *alert = [[NSAlert alloc] init];
+    [alert setMessageText:msgText];
+    [alert setInformativeText:@"Your changes will be lost if you don't save them."];
+
+    [alert addButtonWithTitle:@"Save"];
+    [alert addButtonWithTitle:@"Don't Save"];
+    if (isMulti)
+    {
+        [alert addButtonWithTitle:@"Save All"];
+        [alert addButtonWithTitle:@"Discard All"];
+    }
+    [alert addButtonWithTitle:@"Cancel"];
+
+    switch([alert runModal])
+    {
+        case NSAlertFirstButtonReturn:
+            return CloseActionSave;
+        case NSAlertSecondButtonReturn:
+            return CloseActionDontSave;
+        case NSAlertThirdButtonReturn:
+            return (isMulti) ? CloseActionSaveAll : CloseActionCancel;
+        case NSAlertThirdButtonReturn+1:
+            return CloseActionDiscardAll;
+        case NSAlertThirdButtonReturn+2:
+            return CloseActionCancel;
+    }
+    return CloseActionCancel;
 }
 
 /* OS X doesn't send us a willResize event when leaving fullscreen mode, so: */
@@ -60,7 +195,7 @@
             if (o.via.array.size > 1)
                 mVim->vim_command("tabclose");
             else
-                [self close];
+                [self promptBeforeClosingWindow];
         });
 }
 
@@ -243,6 +378,9 @@
     else if (note ==  "neovim.app.bufchanged") {
         int isModified = update_o.via.array.ptr[0].convert();
         [self setDocumentEdited:isModified?YES:NO];
+    }
+    else if (note ==  "neovim.app.closeTabOrWindow") {
+        [self closeTabOrWindow];
     }
     else {
         std::cout << "Unknown note " << note << "\n";


### PR DESCRIPTION
Added support for a dialog to popup when closing and the close button to show if the current buffer is modified.

Changes:
- res/nvimrc:
    - Added autocmd/function to notify when a buffer has changed inorder
      to update documentEdited
    - Changed MacCloseTabOrWindow() to do rpcnotify instead of "q".
      "q" would fail when more than one file was open, or the document
      was edited. This way there will be a popup if buffers need saving.
    - Moved MacUpdateTitle to be with the other functions
- src/app.mm
    - Added support for closing alert when pressing Cmd-Q.
- src/input.mm
    - Set documentEdited when in insertmode.
- src/window.mm:
    - Added setting documentEdited when a buffer has changed
    - Displays nsalert when there are modified buffers requesting to
      save one or more files
    - On window closing, the Neovim.app will get all the modified
      buffers. Prompt whether one wants to save. If you want to save
      and the file does not have a title, the SavePanel comes up.

This is for issue #103 