### PR TITLE
Added preview when entering accent

### DIFF
--- a/src/input.mm
+++ b/src/input.mm
@@ -23,7 +23,7 @@
         [con handleEvent:event];
     else if (raws.size())
         [self vimInput:raws];
-    else
+    else if (mInsertMode || [self probablyCommandMode])
         [con handleEvent:event];
 }
 

--- a/src/view.h
+++ b/src/view.h
@@ -56,4 +56,6 @@ class Vim;
 - (CGSize)viewSizeFromCellSize:(CGSize)cellSize;
 - (CGSize)cellSizeInsideViewSize:(CGSize)viewSize;
 
+- (BOOL)probablyCommandMode;
+
 @end


### PR DESCRIPTION
Added a preview of the accent that is being entered. Should fix #151. Also removed the `mInsertMode` check so that accents can be entered not just in insertmode but also commandmode. 

@rogual this is the best way that I could find to create a `msgpack::object`. If you know of a better way please let me know. 