### PR TITLE
Update brew tap command

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ See [here](https://github.com/rogual/neovim-dot-app/blob/master/CONTRIBUTING.md)
 ### Install via Homebrew
 
 ```bash
-$ brew tap neovim/homebrew-neovim
+$ brew tap neovim/neovim
 $ brew tap rogual/neovim-dot-app
 $ brew install --HEAD neovim-dot-app
 ```


### PR DESCRIPTION
Official instructions for neovim use `brew tap neovim/neovim` now ([see here](https://github.com/neovim/homebrew-neovim/commit/d75f02521c3da0949562dd1fc9aae3bd15064dd8))