### PR TITLE
Support resizing the window when lines/columns setting is set

### DIFF
--- a/src/redraw.mm
+++ b/src/redraw.mm
@@ -370,6 +370,7 @@ using msgpack::object;
             mYCells = argv[1].convert();
             mCellScrollRect = CGRectMake(0, 0, mXCells, mYCells);
 
+            [self resizeWindow];
             [self setNeedsDisplay:YES];
             break;
         }

--- a/src/view.h
+++ b/src/view.h
@@ -55,5 +55,6 @@ class Vim;
 - (NSPoint)viewPointFromCellPoint:(NSPoint)cellPoint;
 - (CGSize)viewSizeFromCellSize:(CGSize)cellSize;
 - (CGSize)cellSizeInsideViewSize:(CGSize)viewSize;
+- (NSRect)resizeWindow;
 
 @end

--- a/src/view.mm
+++ b/src/view.mm
@@ -168,15 +168,7 @@
         frame = [[[self window] screen] frame];
     }
     else {
-        NSWindow *win = [self window];
-        frame = [win frame];
-        frame = [win contentRectForFrameRect:frame];
-        CGSize cellSize = {(float)mXCells, (float)mYCells};
-
-        frame.size = [self viewSizeFromCellSize:cellSize];
-
-        NSRect winFrame = [win frameRectForContentRect:frame];
-        [win setFrame:winFrame display:NO];
+        frame = [self resizeWindow];
     }
 
     // Tell Vim to resize if necessary
@@ -434,6 +426,20 @@
         mVim->ui_try_resize((int)cellSize.width, (int)cellSize.height);
 }
 
+- (NSRect)resizeWindow
+{
+    NSWindow *win = [self window];
+    NSRect frame = [win frame];
+    frame = [win contentRectForFrameRect:frame];
+    CGSize cellSize = {(float)mXCells, (float)mYCells};
+
+    frame.size = [self viewSizeFromCellSize:cellSize];
+
+    NSRect winFrame = [win frameRectForContentRect:frame];
+    [win setFrame:winFrame display:NO];
+
+    return frame;
+}
 
 /* -- Coordinate conversions -- */
 


### PR DESCRIPTION
Added resizeWindow to view.mm to resize the window based on the current size. Calling it from the `resize` action of the `redraw` message. `resize` action is called by neovim when the screen should be resized. 

This should close out #81 