### PR TITLE
Create a collection of mono fonts and display it when clicking "Show Fonts"

### DIFF
--- a/src/app.mm
+++ b/src/app.mm
@@ -119,9 +119,37 @@ void ignore_sigpipe(void)
     return YES;
 }
 
+/* Makes sure that there is a "Fixed Width" collection.
+   If there isn't it creates a collection called "Fixed Width"
+   adds all monospace fonts to it */
+- (void)ensureFixedWidthCollection
+{
+    NSFontManager *fontManager = [NSFontManager sharedFontManager];
+    NSFontCollection *collection =
+        [NSFontCollection fontCollectionWithName:@"com.apple.AllFonts"];
+
+    NSMutableArray *descriptors = [[NSMutableArray alloc] init];
+    for (NSFontDescriptor *desc in [collection matchingDescriptors])
+    {
+        NSString *name = [desc objectForKey:NSFontNameAttribute];
+        if ([desc symbolicTraits] & NSFontMonoSpaceTrait){
+            [descriptors addObject:desc];
+        }
+    }
+
+    collection = [NSFontCollection fontCollectionWithDescriptors:descriptors];
+
+    /* Add collection only to this process */
+    [NSFontCollection showFontCollection:collection
+        withName:@"Neovim Monospaced"
+        visibility:NSFontCollectionVisibilityProcess
+        error:NULL];
+}
+
 - (void)applicationWillFinishLaunching:(NSNotification *)notification
 {
     [NSFontManager setFontManagerFactory:[VimFontManager class]];
+    [self ensureFixedWidthCollection];
 
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     [defaults registerDefaults:@{@"width": @80,

--- a/src/font.mm
+++ b/src/font.mm
@@ -3,25 +3,10 @@
 @implementation VimFontManager: NSFontManager
 
 /*  Override to return only monospaced fonts.
-    (This is how you write "collections.filter(c -> all(isMonospaced, c.fonts))"
-    when you're paid by the word.) */
+    There has got to be a better way to do this...*/
 - (NSArray *)collectionNames
 {
-    NSArray *cnames = [super collectionNames];
-
-    NSPredicate *collectionIsFixedWidth =
-        [NSPredicate predicateWithBlock:
-            ^(NSString *cname, NSDictionary *bindings) {
-                NSArray *descs = [self fontDescriptorsInCollection:cname];
-                for (NSFontDescriptor *desc in descs) {
-                    if (!([desc symbolicTraits] & NSFontMonoSpaceTrait))
-                        return NO;
-                }
-                return YES;
-            }
-        ];
-
-    return [cnames filteredArrayUsingPredicate:collectionIsFixedWidth];
+    return [NSArray arrayWithObject:@"Neovim Monospaced"];
 }
 
 @end

--- a/src/view.mm
+++ b/src/view.mm
@@ -121,8 +121,7 @@
 - (NSUInteger)validModesForFontPanel:(NSFontPanel *)fontPanel
 {
     return NSFontPanelFaceModeMask |
-           NSFontPanelSizeModeMask |
-           NSFontPanelCollectionModeMask;
+           NSFontPanelSizeModeMask;
 }
 
 - (void)updateCharSize


### PR DESCRIPTION
Only show monospace fonts. At launch of application, a temporary collection called "Neovim Monospaced" is created containing only monospaced fonts. When selecting "Show Fonts", this is the only collection that is displayed.

This should fix issue #92. 