### PR TITLE
Drawing the background rectangle draws an extra pixel

### DIFF
--- a/src/redraw.mm
+++ b/src/redraw.mm
@@ -107,7 +107,7 @@ using msgpack::object;
 
         // Draw background separately [width = item_sz]
         NSRect bgrect = [self
-            viewRectFromCellRect:CGRectMake(mCursorPos.x, mCursorPos.y, item_sz - 1, 1)];
+            viewRectFromCellRect:CGRectMake(mCursorPos.x, mCursorPos.y, item_sz - 1.01, 1)];
         [bg set];
         NSRectFill(bgrect);
 


### PR DESCRIPTION
Fixed vertical line that appears when closing out of an autocomplete window.  This would also happen when there is a vertical split  and one goes up/down a line in the left most window. This was due to an extra pixel being drawn at times when drawing the background. Brought down the width of the drawing of the background and it appears to fix it. 

This should fix #137