### PR TITLE
Start with an empty environment when setting the shell environment

### DIFF
--- a/src/app.mm
+++ b/src/app.mm
@@ -35,9 +35,9 @@ void ignore_sigpipe(void)
         return nil;
     }
 
-    NSArray *args = @[@"-l", @"-c", @"\"env\""];
+    NSArray *args = @[@"-i", shellPath, @"-l", @"-c", @"\"env\""];
     NSTask *task = [NSTask new];
-    task.launchPath = shellPath;
+    task.launchPath = @"/usr/bin/env";
     task.arguments = args;
     task.standardOutput = [NSPipe new];
     task.standardError = [NSPipe new];


### PR DESCRIPTION
The neovim-dot-app process inherits whatever environment variables are
present when it is started. This leads to different behavior when it
is started from the command line or by clicking on the app icon.

Invoking env with -i erases the current environment, before starting a
shell in login mode to probe for the shell's environment. Fixes #84.