### PR TITLE
Add preference to open files in new tabs

### DIFF
--- a/res/nvimrc
+++ b/res/nvimrc
@@ -61,6 +61,10 @@ function! MacCloseTabOrWindow()
     endtry
 endfunction
 
+function! MacSetOpenFilePreference(preference)
+    call rpcnotify(1, "neovim.app.setOpenFilePreference", a:preference)
+endfunction
+
 function! MacUpdateTitle()
     call rpcnotify(1, "neovim.app.updateTitle")
 endfunction

--- a/src/app.h
+++ b/src/app.h
@@ -2,7 +2,7 @@
 
 @interface AppDelegate : NSResponder <NSApplicationDelegate> {
     BOOL didFinishLaunching;
-    NSString *initOpenFile;
+    std::vector<char *> initOpenFiles;
 }
 
 - (void) newWindow;

--- a/src/app.mm
+++ b/src/app.mm
@@ -211,8 +211,10 @@ void ignore_sigpipe(void)
        which Neovim would choke on, so strip it out. */
     std::vector<char *> args;
 
-    if (initOpenFile != NULL) {
-      args.push_back(const_cast<char *>([initOpenFile UTF8String]));
+    if (initOpenFiles.size()) {
+      args.push_back(const_cast<char *>("-p"));
+      for (auto filename : initOpenFiles)
+        args.push_back(filename);
     }
 
     for (int i = 1; i < g_argc ; i++) {
@@ -231,22 +233,29 @@ void ignore_sigpipe(void)
     didFinishLaunching = YES;
 }
 
-/* OSX calls this when the user opens a file with us through Finder. But, that
-   alone would be too easy, so it ALSO parses our command line arguments for
-   us, decides what it thinks is a filename, and calls this for those too.
+/* This is called when a user opens a file with us through Finder, but it's
+   also called when the application is launched with command-line arguments.
+   In the latter case, we need to store the arguments so we can eventually
+   pass them to our Vim instance when we create it.
    Hence the initOpenFile and didFinishLaunching dance. */
-- (BOOL)application:(NSApplication *)app openFile:(NSString *)filename
+- (void)application:(NSApplication *)app openFiles:(NSArray *)filenames
 {
     if (didFinishLaunching) {
-        std::vector<char *> args;
-        args.push_back(const_cast<char *>([filename UTF8String]));
-        activeWindow = [[[VimWindow alloc] initWithArgs:args] retain];
+        BOOL openInTabs = [[NSUserDefaults standardUserDefaults] boolForKey:@"openInTabs"];
+        if (!openInTabs) {
+            /* Default to opening a new window and opening all passed arguments
+               in tabs in that window. */
+            std::vector<char *> args;
+            [self newWindowWithArgs:args];
+        }
+        for (NSString *filename in filenames) {
+            [activeWindow openFilename:filename];
+        }
+    } else {
+        for (NSString *filename in filenames) {
+            initOpenFiles.push_back(const_cast<char *>([filename UTF8String]));
+        }
     }
-    else {
-        initOpenFile = filename;
-        [initOpenFile retain];
-    }
-    return YES;
 }
 
 @end

--- a/src/window.mm
+++ b/src/window.mm
@@ -387,6 +387,28 @@ typedef NS_ENUM(NSInteger, CloseAction) {
     else if (note ==  "neovim.app.closeTabOrWindow") {
         [self closeTabOrWindow];
     }
+    else if (note ==  "neovim.app.setOpenFilePreference") {
+        std::vector<msgpack::object> args = update_o.convert();
+
+        try {
+            if (args.size() != 1) {
+                throw "setOpenFilePreference takes 1 argument: 'new-tab' or 'new-window'";
+            }
+
+            std::string preference = args[0].convert();
+
+	    if (preference == "new-tab") {
+	    	[[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"openInTabs"];
+	    } else if (preference == "new-window") {
+	    	[[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"openInTabs"];
+	    } else {
+                throw "setOpenFilePreference takes 1 argument: 'new-tab' or 'new-window'";
+	    }
+        }
+        catch (std::string msg) {
+            mVim->vim_report_error(msg);
+        }
+    }
     else {
         std::cout << "Unknown note " << note << "\n";
     }


### PR DESCRIPTION
Fixes #182. Adds a "MacSetOpenFilePreference" vim function, which sends a
"neovim.app.setOpenFilePreference" message to the GUI. If the argument to the
function is "new-tab", files dragged to the app/used via "open with" or gnvim
will open in new tabs; if it's "new window", a new window will open and the
files will be opened in tabs in that window.
