### PR TITLE
Save height/width on window resize

### DIFF
--- a/src/window.mm
+++ b/src/window.mm
@@ -33,6 +33,9 @@ typedef NS_ENUM(NSInteger, CloseAction) {
     contentRect.size = [mMainView viewSizeFromCellSize:cellSize];
     frameRect = [sender frameRectForContentRect:contentRect];
 
+    // update the view resize and save
+    [mMainView viewDidEndLiveResize];
+
     return frameRect.size;
 }
 


### PR DESCRIPTION
Resizing window does not always mean that the viewDidEndLiveResize will be called. Calls that method on window resize.

This is for issue #199