### PR TITLE
better detection of $VIM fallback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 NVIM?=$(shell which nvim)
 
 ifneq "$(NVIM)" ""
-VIM?=$(shell $(NVIM) --version | grep 'fall-back' | cut -d '"' -f 2)
+	# TODO the last `grep -v` might not be needed if you could get only the
+	# matching group from sed
+VIM?=$(shell $(NVIM) --version | grep '$VIM' | sed 's/.*$VIM:[ ]*"\(.*\)"/\1/' | grep -v '$VIM')
 endif
 
 all:


### PR DESCRIPTION
Fixes #212. Can be tested with:

```bash
cat <<-EOF |  grep '$VIM' | sed 's/.*$VIM:[ ]*"\(.*\)"/\1/' | grep -v '$VIM'
          System-vimrc-Datei: "\$VIM/sysinit.vim"
     Voreinstellung für \$VIM: "/usr/local/Cellar/neovim/HEAD/share/nvim"

EOF
```