### PR TITLE
Improved loading sequence

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -92,6 +92,16 @@ if not os.path.isdir(vim + '/runtime'):
     )
 else:
     env.Install(res, vim + '/runtime')
+    # Create runtime/after/plugin directory
+    env.Command(
+        res + '/runtime/after/plugin',
+        '',
+        'mkdir -p ' + res + '/runtime/after/plugin'
+    )
+    env.Install(
+        res + '/runtime/after/plugin',
+        'res/zz_source_ginit.vim'
+    )
 
 env.Command(
     'build/Neovim.app/Contents/Resources/Neovim.icns',

--- a/res/nvimrc
+++ b/res/nvimrc
@@ -165,3 +165,7 @@ autocmd BufEnter,BufFilePost,BufWritePost * call MacUpdateTitle()
 
 " Update modified status on all events that could cause a change
 autocmd TextChanged,BufWritePost,InsertEnter,InsertLeave,BufEnter,BufLeave * call MacBufChanged()
+
+if filereadable(expand("~/.config/nvim/init.vim"))
+    source ~/.config/nvim/init.vim
+endif

--- a/res/nvimrc
+++ b/res/nvimrc
@@ -169,3 +169,6 @@ autocmd TextChanged,BufWritePost,InsertEnter,InsertLeave,BufEnter,BufLeave * cal
 if filereadable(expand("~/.config/nvim/init.vim"))
     source ~/.config/nvim/init.vim
 endif
+
+let s:path = fnamemodify(resolve(expand('<sfile>:p')), ':h')
+exec 'set rtp+=' . s:path . '/runtime/after'

--- a/res/zz_source_ginit.vim
+++ b/res/zz_source_ginit.vim
@@ -1,0 +1,5 @@
+if filereadable(expand("~/.config/nvim/ginit.vim"))
+    source ~/.config/nvim/ginit.vim
+elseif filereadable(expand("~/.gvimrc"))
+    source ~/.gvimrc
+endif

--- a/src/app.mm
+++ b/src/app.mm
@@ -227,6 +227,7 @@ void ignore_sigpipe(void)
 
         args.push_back(g_argv[i]);
     }
+    [self prepareNvimArgs:args];
     [self newWindowWithArgs:args];
 
     didFinishLaunching = YES;
@@ -241,6 +242,7 @@ void ignore_sigpipe(void)
     if (didFinishLaunching) {
         std::vector<char *> args;
         args.push_back(const_cast<char *>([filename UTF8String]));
+        [self prepareNvimArgs:args];
         activeWindow = [[[VimWindow alloc] initWithArgs:args] retain];
     }
     else {
@@ -248,6 +250,23 @@ void ignore_sigpipe(void)
         [initOpenFile retain];
     }
     return YES;
+}
+
+- (void)prepareNvimArgs:(std::vector<char *> &) args
+{
+    bool didSupplyNvimrc = NO;
+    for(std::vector<char *>::iterator it = args.begin(); it != args.end(); ++it) {
+        if (!strcmp("-u", *it)) {
+            didSupplyNvimrc = YES;
+        }
+    }
+
+    if (!didSupplyNvimrc) {
+        NSString *nvimrcPath = [[NSBundle mainBundle] pathForResource:@"nvimrc"
+                                                      ofType:nil];
+        args.push_back(const_cast<char *>("-u"));
+        args.push_back(const_cast<char *>([nvimrcPath UTF8String]));
+    }
 }
 
 @end

--- a/src/window.mm
+++ b/src/window.mm
@@ -230,13 +230,6 @@ typedef NS_ENUM(NSInteger, CloseAction) {
     mVim = new Vim([vimPath UTF8String], args);
     mVim->ui_attach(width, height, true);
 
-    /* Reload .nvimrc after connecting to get any settings requiring
-       gui_running to be re-evaluated as true.
-       This should be removed after an implementation similar to
-       https://github.com/neovim/python-client/issues/106
-       is done. */
-    mVim->vim_command("so $MYVIMRC");
-
     /* As a courtesy, warn if any T- mappings are set */
     mVim->vim_command_output("silent map").then([self](std::string mappings) {
         if (mappings.find("T-") != std::string::npos) {


### PR DESCRIPTION
This does a few things:

1. Launches neovim with `-u Neovim.app/Resources/nvimrc`, unless specified already by the command line
2. Adds `Neovim.app/Resources/runtime/after` to the `runtimepath` so that ...
3. `ginit.vim` is sourced

I tried doing `mVim->vim_command("so ~/.config/nvim/init.vim");`, but it happens too late in the startup and some `autocmd`s weren't working.