### PR TITLE
Remove instructions to install with --HEAD

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ See [here](https://github.com/rogual/neovim-dot-app/blob/master/CONTRIBUTING.md)
 ```bash
 $ brew tap neovim/neovim
 $ brew tap rogual/neovim-dot-app
-$ brew install --HEAD neovim-dot-app
+$ brew install neovim-dot-app
 $ brew linkapps neovim-dot-app
 ```
 


### PR DESCRIPTION
Given you cut a release I figure this makes sense.

Also, `brew install --HEAD neovim` will build with a version of 0.1.3-dev which means `brew install --HEAD neovim-dot-app` will not build against it, so using the release is currently the only way to get this from homebrew (unless I am mistaken).