### PR TITLE
env -i will ignore inherited envrionment

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -16,7 +16,7 @@ except OSError:
 env.Append(
     CCFLAGS=['-std=c++11', '-stdlib=libc++', '-g', '-Wno-deprecated-register'],
     CPPPATH=['build'],
-    LIBS=['c++', 'msgpack'],
+    LIBS=['c++', 'msgpackc'],
     FRAMEWORKS=['Cocoa', 'Carbon']
 )
 

--- a/src/app.mm
+++ b/src/app.mm
@@ -35,7 +35,7 @@ void ignore_sigpipe(void)
         return nil;
     }
 
-    NSArray *args = @[@"-i", shellPath, @"-l", @"-c", @"\"env\""];
+    NSArray *args = @[shellPath, @"-l", @"-c", @"\"env\""];
     NSTask *task = [NSTask new];
     task.launchPath = @"/usr/bin/env";
     task.arguments = args;


### PR DESCRIPTION
/usr/bin/env -i will ignore inherited envrionment

envrionments which set in ~/.zshrc or ~/.zshenv will be ignored