### PR TITLE
update msgpack library name

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -16,7 +16,7 @@ except OSError:
 env.Append(
     CCFLAGS=['-std=c++11', '-stdlib=libc++', '-g', '-Wno-deprecated-register'],
     CPPPATH=['build'],
-    LIBS=['c++', 'msgpack'],
+    LIBS=['c++', 'msgpackc'],
     FRAMEWORKS=['Cocoa', 'Carbon']
 )
 


### PR DESCRIPTION
msgpack library got renamed to msgpackc [PR #50534 on homebrew](https://github.com/Homebrew/homebrew/pull/50534)

without fix build fails with:
```
VIM=/usr/local/Cellar/neovim/HEAD/share/nvim NVIM=/usr/local/bin/nvim scons -Q
WARNING: Could not determine exact Neovim version. If your Neovim is not up to date, there may be incompatibilities.
Install file: "res/Info.plist" as "build/Neovim.app/Contents/Info.plist"
clang++ -o build/client.o -c -std=c++11 -stdlib=libc++ -g -Wno-deprecated-register -I/usr/local/Cellar/msgpack/1.4.1/include -Ibuild -Isrc src/client.cc
clang++ -o build/process.o -c -std=c++11 -stdlib=libc++ -g -Wno-deprecated-register -I/usr/local/Cellar/msgpack/1.4.1/include -Ibuild -Isrc src/process.cc
clang++ -o build/rpc.o -c -std=c++11 -stdlib=libc++ -g -Wno-deprecated-register -I/usr/local/Cellar/msgpack/1.4.1/include -Ibuild -Isrc src/rpc.cc
clang++ -o build/vim.o -c -std=c++11 -stdlib=libc++ -g -Wno-deprecated-register -I/usr/local/Cellar/msgpack/1.4.1/include -Ibuild -Isrc src/vim.cc
clang++ -o build/vimutils.o -c -std=c++11 -stdlib=libc++ -g -Wno-deprecated-register -I/usr/local/Cellar/msgpack/1.4.1/include -Ibuild -Isrc src/vimutils.cc
clang++ -o build/app.o -c -std=c++11 -stdlib=libc++ -g -Wno-deprecated-register -I/usr/local/Cellar/msgpack/1.4.1/include -Ibuild -Isrc src/app.mm
clang++ -o build/font.o -c -std=c++11 -stdlib=libc++ -g -Wno-deprecated-register -I/usr/local/Cellar/msgpack/1.4.1/include -Ibuild -Isrc src/font.mm
clang++ -o build/graphics.o -c -std=c++11 -stdlib=libc++ -g -Wno-deprecated-register -I/usr/local/Cellar/msgpack/1.4.1/include -Ibuild -Isrc src/graphics.mm
clang++ -o build/input.o -c -std=c++11 -stdlib=libc++ -g -Wno-deprecated-register -I/usr/local/Cellar/msgpack/1.4.1/include -Ibuild -Isrc src/input.mm
clang++ -o build/keys.o -c -std=c++11 -stdlib=libc++ -g -Wno-deprecated-register -I/usr/local/Cellar/msgpack/1.4.1/include -Ibuild -Isrc src/keys.mm
clang++ -o build/main.o -c -std=c++11 -stdlib=libc++ -g -Wno-deprecated-register -I/usr/local/Cellar/msgpack/1.4.1/include -Ibuild -Isrc src/main.mm
clang++ -o build/menu.o -c -std=c++11 -stdlib=libc++ -g -Wno-deprecated-register -I/usr/local/Cellar/msgpack/1.4.1/include -Ibuild -Isrc src/menu.mm
gperf -cCD -L C++ -Z RedrawHash -t src/redraw.gperf > build/redraw-hash.gen.h
clang++ -o build/redraw.o -c -std=c++11 -stdlib=libc++ -g -Wno-deprecated-register -I/usr/local/Cellar/msgpack/1.4.1/include -Ibuild -Isrc src/redraw.mm
clang++ -o build/view.o -c -std=c++11 -stdlib=libc++ -g -Wno-deprecated-register -I/usr/local/Cellar/msgpack/1.4.1/include -Ibuild -Isrc src/view.mm
clang++ -o build/window.o -c -std=c++11 -stdlib=libc++ -g -Wno-deprecated-register -I/usr/local/Cellar/msgpack/1.4.1/include -Ibuild -Isrc src/window.mm
clang++ -o build/Neovim.app/Contents/MacOS/Neovim build/client.o build/process.o build/rpc.o build/vim.o build/vimutils.o build/app.o build/font.o build/graphics.o build/input.o build/keys.o build/main.o build/menu.o build/redraw.o build/view.o build/window.o -L/usr/local/Cellar/msgpack/1.4.1/lib -lmsgpackc -lc++ -lmsgpack -framework Cocoa -framework Carbon
ld: library not found for -lmsgpack
clang: error: linker command failed with exit code 1 (use -v to see invocation)
scons: *** [build/Neovim.app/Contents/MacOS/Neovim] Error 1
make: *** [all] Error 2
```

tested on OSX: 10.11.4