### PR TITLE
Allow deadkeys that do not require a modifier key to work

### DIFF
--- a/src/input.mm
+++ b/src/input.mm
@@ -15,16 +15,18 @@
     NSTextInputContext *con = [NSTextInputContext currentInputContext];
     [NSCursor setHiddenUntilMouseMoves:YES];
 
-    std::stringstream raw;
-    translateKeyEvent(raw, event);
-    std::string raws = raw.str();
+    /* When a deadkey is received on keydown the length is 0. Allow
+       NSTextInputContext to handle the key press */
+    if ([[event characters] length] == 0 || [self hasMarkedText])
+        [con handleEvent:event];
+    else {
+        std::stringstream raw;
+        translateKeyEvent(raw, event);
+        std::string raws = raw.str();
 
-    if ([self hasMarkedText])
-        [con handleEvent:event];
-    else if (raws.size())
-        [self vimInput:raws];
-    else if (mInsertMode || [self probablyCommandMode])
-        [con handleEvent:event];
+        if (raws.size())
+            [self vimInput:raws];
+    }
 }
 
 - (void)mouseEvent:(NSEvent *)event drag:(BOOL)drag type:(const char *)type


### PR DESCRIPTION
Improved deadkey recognition. Now it should work on layouts where a modifier key is not required for deadkeys. This pr is for issue #221. I tested it with a greek layout and it seemed to work fine with the `;e` being `έ`. I also tried other random letters and was able to get `άίόύ`. 