### PR TITLE
Added ability to enable/disable Anti-aliasing

### DIFF
--- a/res/nvimrc
+++ b/res/nvimrc
@@ -95,6 +95,10 @@ function! MacOpenFileInBufferOrNewTab(filename)
     endif
 endfunction
 
+function! MacFontShouldAntialias(value)
+    call rpcnotify(1, "neovim.app.shouldAntialias", a:value)
+endfunction
+
 
 " First, load the default menus
 runtime menu.vim

--- a/src/app.mm
+++ b/src/app.mm
@@ -167,8 +167,7 @@ void ignore_sigpipe(void)
                                  @"left": @0,
                                  @"bottom": @0,
                                  @"fontName": @"Menlo",
-                                 @"fontSize": @11.0,
-                                 @"shouldAntialias": @YES}];
+                                 @"fontSize": @11.0}];
 
     [self loadLoginShellEnvironmentVariables];
 

--- a/src/app.mm
+++ b/src/app.mm
@@ -167,7 +167,8 @@ void ignore_sigpipe(void)
                                  @"left": @0,
                                  @"bottom": @0,
                                  @"fontName": @"Menlo",
-                                 @"fontSize": @11.0}];
+                                 @"fontSize": @11.0,
+                                 @"shouldAntialias": @YES}];
 
     [self loadLoginShellEnvironmentVariables];
 

--- a/src/view.h
+++ b/src/view.h
@@ -43,6 +43,7 @@ class Vim;
 
 - (void)setFont:(NSFont *)font;
 - (void)setFontProgramatically:(NSFont *)font;
+- (void)setShouldAntialias:(BOOL)shouldAntialias;
 
 - (void)openFile:(NSString *)filename;
 

--- a/src/view.mm
+++ b/src/view.mm
@@ -80,6 +80,10 @@
     );
     assert (mCanvasContext);
 
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    BOOL shouldAntialias = [defaults boolForKey:@"shouldAntialias"]; 
+    CGContextSetShouldAntialias(mCanvasContext, shouldAntialias);
+
     CGContextSaveGState(mCanvasContext);
     [self updateScale];
 
@@ -98,6 +102,7 @@
     }
     return self;
 }
+
 
 - (void)updateScale
 {
@@ -200,6 +205,14 @@
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     [defaults setObject:mFont.fontName forKey:@"fontName"];
     [defaults setFloat:mFont.pointSize forKey:@"fontSize"];
+}
+
+- (void)setShouldAntialias:(BOOL)shouldAntialias
+{
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    [defaults setBool:shouldAntialias forKey:@"shouldAntialias"];
+    CGContextSetShouldAntialias(mCanvasContext, shouldAntialias);
+    mVim->vim_command("redraw!");
 }
 
 - (void)cutText

--- a/src/view.mm
+++ b/src/view.mm
@@ -80,13 +80,8 @@
     );
     assert (mCanvasContext);
 
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    BOOL shouldAntialias = [defaults boolForKey:@"shouldAntialias"]; 
-    CGContextSetShouldAntialias(mCanvasContext, shouldAntialias);
-
     CGContextSaveGState(mCanvasContext);
     [self updateScale];
-
 }
 
 - (id)initWithCellSize:(CGSize)cellSize vim:(Vim *)vim
@@ -209,8 +204,6 @@
 
 - (void)setShouldAntialias:(BOOL)shouldAntialias
 {
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    [defaults setBool:shouldAntialias forKey:@"shouldAntialias"];
     CGContextSetShouldAntialias(mCanvasContext, shouldAntialias);
     mVim->vim_command("redraw!");
 }

--- a/src/window.mm
+++ b/src/window.mm
@@ -408,6 +408,10 @@ typedef NS_ENUM(NSInteger, CloseAction) {
     else if (note ==  "neovim.app.closeTabOrWindow") {
         [self closeTabOrWindow];
     }
+    else if (note ==  "neovim.app.shouldAntialias") {
+        BOOL shouldAntialias = update_o.via.array.ptr[0].convert();
+        [mMainView setShouldAntialias:shouldAntialias];
+    }
     else {
         std::cout << "Unknown note " << note << "\n";
     }


### PR DESCRIPTION
One can now call `MacFontShouldAntialias()` with `1` or `0` to enable/disable Anti-aliasing on fonts.

This is for #220