### PR TITLE
Catch the <C-Tab> & <C-S-Tab> keys and send to keyDown

### DIFF
--- a/src/input.mm
+++ b/src/input.mm
@@ -27,6 +27,21 @@
         [con handleEvent:event];
 }
 
+- (BOOL)performKeyEquivalent:(NSEvent *)event
+{
+    NSEventType type = [event type];
+    unsigned flags = [event modifierFlags];
+
+    /* <C-Tab> & <C-S-Tab> do not trigger keyDown events.
+       Catch the key event here and pass iti to keyDown. */
+    if (NSKeyDown == type && NSControlKeyMask & flags && 48 == [event keyCode]) {
+        [self keyDown:event];
+        return YES;
+    }
+    
+    return NO;
+}
+
 - (void)mouseEvent:(NSEvent *)event drag:(BOOL)drag type:(const char *)type
 {
     NSPoint cellLoc = [self cellContainingEvent:event];


### PR DESCRIPTION
`<C-Tab>` and `<C-S-Tab>` are not passed to the `-keyDown:` event. Added `-performKeyEquivalent:` to capture those keys and pass them on to `-keyDown:` event. 

This is for issue #190 