### PR TITLE
Added macmeta support

### DIFF
--- a/doc/nvim_dot_app.txt
+++ b/doc/nvim_dot_app.txt
@@ -48,6 +48,11 @@ MacShowFontSelector()
     Fonts chosen from the GUI font selector are stored to User Defaults, and
     take effect on startup until overridden by a MacSetFont call.
 
+MacSetOptionAsMeta(value)
+    If value is 1, pressing the option (alt) key will be interpreted as a 
+    meta command. With this set any option hotkeys are bindable as <M-..>.
+    If the value is 0, all option keys are interpreted as normal (the default).
+
 MacSetFontShouldAntialias(value)
     If value is 1, enable font antialiasing (the default). If value is 0,
     disable it. Calling with any other value is undefined behaviour.

--- a/res/nvimrc
+++ b/res/nvimrc
@@ -95,6 +95,10 @@ function! MacOpenFileInBufferOrNewTab(filename)
     endif
 endfunction
 
+function! MacSetMacmeta(value)
+    call rpcnotify(1, "neovim.app.setmacmeta", a:value)
+endfunction
+
 
 " First, load the default menus
 runtime menu.vim

--- a/src/input.mm
+++ b/src/input.mm
@@ -15,13 +15,16 @@
     NSTextInputContext *con = [NSTextInputContext currentInputContext];
     [NSCursor setHiddenUntilMouseMoves:YES];
 
-    /* When a deadkey is received on keydown the length is 0. Allow
-       NSTextInputContext to handle the key press */
-    if ([[event characters] length] == 0 || [self hasMarkedText])
+    /* When a deadkey is received the character length is 0. Allow
+       NSTextInputContext to handle the key press only if Macmeta is
+       not turned on */
+    if ([self hasMarkedText]) {
         [con handleEvent:event];
-    else {
+    } else if (!mMacmetaEnabled && ([[event characters] length] == 0)) {
+        [con handleEvent:event];
+    } else {
         std::stringstream raw;
-        translateKeyEvent(raw, event);
+        translateKeyEvent(raw, event, mMacmetaEnabled);
         std::string raws = raw.str();
 
         if (raws.size())
@@ -40,7 +43,7 @@
         [self keyDown:event];
         return YES;
     }
-    
+   
     return NO;
 }
 

--- a/src/keys.h
+++ b/src/keys.h
@@ -2,6 +2,6 @@
 
 @class NSEvent;
 
-void addModifiedName(std::ostream &, NSEvent *, const char *name);
-void translateKeyEvent(std::ostream &, unsigned short keyCode, unsigned flags);
-void translateKeyEvent(std::ostream &, NSEvent *);
+void addModifiedName(std::ostream &, NSEvent *, const char *);
+void translateKeyEvent(std::ostream &, unsigned short, unsigned, BOOL);
+void translateKeyEvent(std::ostream &, NSEvent *, BOOL);

--- a/src/keys.mm
+++ b/src/keys.mm
@@ -78,7 +78,7 @@ static NSString *stringFromModifiedKey(unsigned keyCode, unsigned modifiers)
     const UCKeyboardLayout *layout =
         (const UCKeyboardLayout *)CFDataGetBytePtr(layoutData);
 
-    unsigned deadKeyState;
+    unsigned deadKeyState = 0;
     unichar chars[5];
     UniCharCount numChars;
 
@@ -146,7 +146,7 @@ void addModifiedName(std::ostream &os, NSEvent *event, const char *name)
     addModifiedName(os, [event modifierFlags], clickCount, name);
 }
 
-void translateKeyEvent(std::ostream &os, unsigned short keyCode, unsigned flags)
+void translateKeyEvent(std::ostream &os, unsigned short keyCode, unsigned flags, BOOL enableMacmeta)
 {
     const char *name = keyName(keyCode);
 
@@ -174,11 +174,11 @@ void translateKeyEvent(std::ostream &os, unsigned short keyCode, unsigned flags)
         than sending the alternate character for that key; nobody wants to
         map <C-∆> */
     if (flags & NSAlternateKeyMask)
-    if (flags & (NSCommandKeyMask | NSControlKeyMask)) {
-        chars = stringFromModifiedKey(keyCode, flags & NSShiftKeyMask);
-        sendflags |= NSAlternateKeyMask;
-        flags &= ~NSAlternateKeyMask;
-    }
+        if (flags & (NSCommandKeyMask | NSControlKeyMask) || enableMacmeta) {
+            chars = stringFromModifiedKey(keyCode, flags & NSShiftKeyMask);
+            sendflags |= NSAlternateKeyMask;
+            flags &= ~NSAlternateKeyMask;
+        }
 
     /* Vim doesn't distinguish between <C-j> and <C-J>, so let's send the
         S- modifier if:
@@ -214,7 +214,7 @@ void translateKeyEvent(std::ostream &os, unsigned short keyCode, unsigned flags)
     }
 }
 
-void translateKeyEvent(std::ostream &os, NSEvent *event)
+void translateKeyEvent(std::ostream &os, NSEvent *event, BOOL enableMacmeta)
 {
     unsigned short keyCode = [event keyCode];
 
@@ -227,5 +227,5 @@ void translateKeyEvent(std::ostream &os, NSEvent *event)
         NSCommandKeyMask
     );
 
-    translateKeyEvent(os, keyCode, flags);
+    translateKeyEvent(os, keyCode, flags, enableMacmeta);
 }

--- a/src/tests/main.mm
+++ b/src/tests/main.mm
@@ -12,7 +12,7 @@ extern TISInputSourceRef g_input_source;
 static void test(unsigned short keyCode, unsigned flags, std::string expected)
 {
     std::stringstream ss;
-    translateKeyEvent(ss, keyCode, flags);
+    translateKeyEvent(ss, keyCode, flags, NO);
     std::string got = ss.str();
     if (got != expected) {
         pass = false;

--- a/src/view.h
+++ b/src/view.h
@@ -35,6 +35,7 @@ class Vim;
     bool mMenuNeedsUpdate;
 
     NSString *mMarkedText;
+    BOOL mMacmetaEnabled;
 }
 
 - (void)cutText;
@@ -43,6 +44,8 @@ class Vim;
 
 - (void)setFont:(NSFont *)font;
 - (void)setFontProgramatically:(NSFont *)font;
+
+- (void)setMacmeta:(BOOL)isEnabled;
 
 - (void)openFile:(NSString *)filename;
 

--- a/src/view.mm
+++ b/src/view.mm
@@ -47,6 +47,8 @@
         mCursorPos = mCursorDisplayPos = CGPointZero;
         mCursorOn = true;
 
+        mMacmetaEnabled = NO;
+
         [self registerForDraggedTypes:[NSArray arrayWithObjects: NSFilenamesPboardType, nil]];
     }
 
@@ -200,6 +202,11 @@
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     [defaults setObject:mFont.fontName forKey:@"fontName"];
     [defaults setFloat:mFont.pointSize forKey:@"fontSize"];
+}
+
+- (void)setMacmeta:(BOOL)isEnabled
+{
+    mMacmetaEnabled = isEnabled;
 }
 
 - (void)cutText

--- a/src/window.mm
+++ b/src/window.mm
@@ -408,6 +408,10 @@ typedef NS_ENUM(NSInteger, CloseAction) {
     else if (note ==  "neovim.app.closeTabOrWindow") {
         [self closeTabOrWindow];
     }
+    else if (note ==  "neovim.app.setmacmeta") {
+        BOOL macmetaOn = update_o.via.array.ptr[0].convert();
+        [mMainView setMacmeta:macmetaOn];
+    }
     else {
         std::cout << "Unknown note " << note << "\n";
     }


### PR DESCRIPTION
Added macmeta support as requested in #249 and #86. This only translates the Meta/Alt/Option key as such. It does not interpret the Command key as a Meta key. This can be turned on by calling:

```viml
call MacSetMacmeta(1)
```