### PR TITLE
Update doc glob to look in project root directory

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -99,7 +99,7 @@ if not os.path.isdir(vim + '/runtime'):
     )
 else:
     env.Install(res, vim + '/runtime')
-    env.Install(os.path.join(res, 'runtime/doc'), env.Glob('doc/*'))
+    env.Install(os.path.join(res, 'runtime/doc'), env.Glob('../doc/*'))
 
 env.Command(
     'build/Neovim.app/Contents/Resources/Neovim.icns',


### PR DESCRIPTION
In response to #253:

The error in this issue appears to happen [here](https://github.com/rogual/neovim-dot-app/blob/master/SConstruct#L102), where the neovim-dot-app docs are added to the nvim docs within the built app (`build/Neovim.app/Contents/Resources/runtime/doc`). This error is only encountered on clean builds, and not on subsequent builds.

While not well versed in `scons`, it seems that this is caused by this [line](https://github.com/rogual/neovim-dot-app/blob/master/SConstruct#L66). Based on my research, the `VariantDirectory` is only set when the build dir does not yet exist. It seems this causes the `doc` install to look relative to this directory, and errors since all of the `doc` files are already present. The fix was to look up one directory from the `build` dir, which would be the project root, and here the `doc` dir can be found and its files can be written. On subsequent builds, the `VariantDir` is not set, the `doc` dir is located in the project root and everything succeeds again.

There might be a better way to do this according to `scons` best practices, but this is how I got it to work.
