### PR TITLE
Enviornment value is joined by '='

### DIFF
--- a/src/app.mm
+++ b/src/app.mm
@@ -57,14 +57,15 @@ void ignore_sigpipe(void)
     NSMutableDictionary *env = [NSMutableDictionary new];
 
     for (NSString *s in envVars) {
-        NSArray *keyvalue = [s componentsSeparatedByString:@"="];
+        NSMutableArray *keyvalue = [[s componentsSeparatedByString:@"="] mutableCopy];
 
         if (keyvalue.count < 2) {
             continue;
         }
 
         NSString *key = keyvalue[0];
-        NSString *value = keyvalue[1];
+        [keyvalue removeObjectAtIndex:0];
+        NSString *value = [keyvalue componentsJoinedByString:@"="];
 
         env[key] = value;
     }


### PR DESCRIPTION
The split environment variable now gets joined with `=` excluding the first value of the array (which is the key). 

This should fix #256 
