### PR TITLE
Fixed setting the environment variables

### DIFF
--- a/src/app.mm
+++ b/src/app.mm
@@ -35,9 +35,9 @@ void ignore_sigpipe(void)
         return nil;
     }
 
-    NSArray *args = @[@"-i", shellPath, @"-l", @"-c", @"\"env\""];
+    NSArray *args = @[@"-l", @"-c", @"env", @"-i"];
     NSTask *task = [NSTask new];
-    task.launchPath = @"/usr/bin/env";
+    task.launchPath = shellPath;
     task.arguments = args;
     task.standardOutput = [NSPipe new];
     task.standardError = [NSPipe new];


### PR DESCRIPTION
Environment was setup incorrectly. The shell should be launched with `-l` and have it call `env -i`. 

This should close #235 and fix #84