### PR TITLE
Compatability for msgpack-c 2.0

### DIFF
--- a/src/client.cc
+++ b/src/client.cc
@@ -45,7 +45,7 @@ again:
        we parsed last time from memory. */
     unpacked = msgpack::unpacked();
 
-    while(unpacker.next(&unpacked)) {
+    while(unpacker.next(unpacked)) {
 
         msgpack::object item = unpacked.get();
 

--- a/src/input.mm
+++ b/src/input.mm
@@ -159,7 +159,7 @@
     pk.pack(cursordata);
 
     msgpack::unpacked msg;
-    msgpack::unpack(&msg, sbuf.data(), sbuf.size());
+    msgpack::unpack(msg, sbuf.data(), sbuf.size());
     msgpack::object obj = msg.get();
 
     [self redraw:obj];


### PR DESCRIPTION
The current version of `msgpack` on Homebrew is now 2.0 which deprecates the `unpack` API used in this project. This pull request updates the calls to the reference version of the API.

I noticed this when I was no longer able to build from source on OS X after upgrading msgpack via Homebrew.

See: [Changelog](https://github.com/msgpack/msgpack-c/releases/tag/cpp-2.0.0) and [Commit](https://github.com/msgpack/msgpack-c/pull/453)