### PR TITLE
Support for one or more option keys as meta characters

### DIFF
--- a/doc/nvim_dot_app.txt
+++ b/doc/nvim_dot_app.txt
@@ -49,9 +49,13 @@ MacShowFontSelector()
     take effect on startup until overridden by a MacSetFont call.
 
 MacSetOptionAsMeta(value)
-    If value is 1, pressing the option (alt) key will be interpreted as a 
-    meta command. With this set any option hotkeys are bindable as <M-..>.
-    If the value is 0, all option keys are interpreted as normal (the default).
+    Valid values: "None", "Left", "Right", "Either", "Both"
+
+    The provided option will set the "Left" or "Right" option (alt) key to be
+    interpreted as a meta command. With this set any option hotkeys are
+    bindable as <M-..>. The "Either" value allows for either Option key to be
+    interpreted.  "Both" requires that both Option keys be pressed. The default
+    option is "None".
 
 MacSetFontShouldAntialias(value)
     If value is 1, enable font antialiasing (the default). If value is 0,

--- a/src/input.h
+++ b/src/input.h
@@ -1,6 +1,14 @@
 #include <string>
 
+const int META_NONE  = 0x00000;
+const int META_EITHER = 0x80100;
+const int META_LEFT  = 0x80120;
+const int META_RIGHT = 0x80140;
+const int META_BOTH = 0x80160;
+
 @interface VimView (Input)<NSTextInputClient>
+
+- (BOOL)hasOptAsMetaForModifier:(int)modifiers;
 
 - (void)vimInput:(const std::string &)input;
 

--- a/src/input.mm
+++ b/src/input.mm
@@ -15,21 +15,34 @@
     NSTextInputContext *con = [NSTextInputContext currentInputContext];
     [NSCursor setHiddenUntilMouseMoves:YES];
 
+    BOOL useOptAsMeta = [self hasOptAsMetaForModifier:[event modifierFlags]];
+
     /* When a deadkey is received the character length is 0. Allow
        NSTextInputContext to handle the key press only if Macmeta is
        not turned on */
     if ([self hasMarkedText]) {
         [con handleEvent:event];
-    } else if (!mOptAsMeta && ([[event characters] length] == 0)) {
+    } else if (!useOptAsMeta && ([[event characters] length] == 0)) {
         [con handleEvent:event];
     } else {
         std::stringstream raw;
-        translateKeyEvent(raw, event, mOptAsMeta);
+        translateKeyEvent(raw, event, useOptAsMeta);
         std::string raws = raw.str();
 
         if (raws.size())
             [self vimInput:raws];
     }
+}
+
+- (BOOL)hasOptAsMetaForModifier:(int)modifiers
+{
+    if (!mOptAsMeta)
+        return NO;
+
+    if (mOptAsMeta == META_EITHER)
+        return (modifiers & mOptAsMeta) == mOptAsMeta;
+
+    return modifiers == mOptAsMeta;
 }
 
 - (BOOL)performKeyEquivalent:(NSEvent *)event
@@ -43,7 +56,7 @@
         [self keyDown:event];
         return YES;
     }
-   
+
     return NO;
 }
 

--- a/src/view.h
+++ b/src/view.h
@@ -35,7 +35,7 @@ class Vim;
     bool mMenuNeedsUpdate;
 
     NSString *mMarkedText;
-    BOOL mOptAsMeta;
+    int mOptAsMeta;
 }
 
 - (void)cutText;
@@ -46,7 +46,7 @@ class Vim;
 - (void)setFontProgramatically:(NSFont *)font;
 - (void)setShouldAntialias:(BOOL)shouldAntialias;
 
-- (void)setOptionAsMeta:(BOOL)isEnabled;
+- (void)setOptionAsMetaForKey:(NSString *)key;
 
 - (void)openFile:(NSString *)filename;
 

--- a/src/view.mm
+++ b/src/view.mm
@@ -47,7 +47,7 @@
         mCursorPos = mCursorDisplayPos = CGPointZero;
         mCursorOn = true;
 
-        mOptAsMeta = NO;
+        mOptAsMeta = META_NONE;
 
         [self registerForDraggedTypes:[NSArray arrayWithObjects: NSFilenamesPboardType, nil]];
     }
@@ -209,9 +209,18 @@
     [defaults setFloat:mFont.pointSize forKey:@"fontSize"];
 }
 
-- (void)setOptionAsMeta:(BOOL)isEnabled
+- (void)setOptionAsMetaForKey:(NSString *)key
 {
-    mOptAsMeta = isEnabled;
+    if ([key isEqual:@"left"])
+        mOptAsMeta = META_LEFT;
+    else if ([key isEqual:@"right"])
+        mOptAsMeta = META_RIGHT;
+    else if ([key isEqual:@"either"])
+        mOptAsMeta = META_EITHER;
+    else if ([key isEqual:@"both"])
+        mOptAsMeta = META_BOTH;
+    else
+        mOptAsMeta = META_NONE;
 }
 
 - (void)setShouldAntialias:(BOOL)shouldAntialias

--- a/src/window.mm
+++ b/src/window.mm
@@ -409,8 +409,9 @@ typedef NS_ENUM(NSInteger, CloseAction) {
         [self closeTabOrWindow];
     }
     else if (note == "neovim.app.setOptAsMeta") {
-        BOOL optAsMeta = update_o.via.array.ptr[0].convert();
-        [mMainView setOptionAsMeta:optAsMeta];
+        std::string optAsMeta = update_o.via.array.ptr[0].convert();
+        NSString *option = [[NSString stringWithUTF8String:optAsMeta.c_str()] lowercaseString];
+        [mMainView setOptionAsMetaForKey:option];
     }
     else if (note == "neovim.app.shouldAntialias") {
         BOOL shouldAntialias = update_o.via.array.ptr[0].convert();


### PR DESCRIPTION
RE: #265 & #86 

This pull request adds support for mapping the option keys as meta. Can use the left, right, both (at the same time), either, or none. 
