### PR TITLE
Fix localized --version ill formated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,7 @@
 NVIM?=$(shell which nvim)
 
 ifneq "$(NVIM)" ""
-	# TODO the last `grep -v` might not be needed if you could get only the
-	# matching group from sed
-VIM?=$(shell $(NVIM) --version | grep '$VIM' | sed 's/.*$VIM:[ ]*"\(.*\)"/\1/' | grep -v '$VIM')
+VIM?=$(shell $(NVIM) --version | tr -d '\n' | egrep -o '$VIM.*:.*"' | sed 's/.*$VIM.*:[ ]*"\(.*\)"/\1/')
 endif
 
 all:


### PR DESCRIPTION
Makefile now ignores any newline characters from --version that come from
random newline characters with different locales.

Tested:
- de_DE.UTF-8
- en_US.UTF-8
- zh_TW.UTF-8
- ja_JP.UTF-8

This should be a fix for #282 
