### PR TITLE
Disable ligatures to prevent rendering issues

### DIFF
--- a/src/view.mm
+++ b/src/view.mm
@@ -31,6 +31,7 @@
         mTextAttrs = [[NSMutableDictionary dictionaryWithObjectsAndKeys:
             mForegroundColor, NSForegroundColorAttributeName,
             mBackgroundColor, NSBackgroundColorAttributeName,
+            @0,               NSLigatureAttributeName,
             nil
         ] retain];
 


### PR DESCRIPTION
Fix for #304. Added the value `0` for the key `NSLigatureAttributeName` in `mTextAttrs` to disable drawing ligatures.
