### PR TITLE
Update outdated README instructions: replace brew linkapps

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ See [here](https://github.com/rogual/neovim-dot-app/blob/master/CONTRIBUTING.md)
 $ brew tap neovim/neovim
 $ brew tap rogual/neovim-dot-app
 $ brew install neovim-dot-app
-$ brew linkapps neovim-dot-app
+$ ln -s /usr/local/opt/neovim-dot-app /Applications
 ```
 
 ### Install manually


### PR DESCRIPTION
Since `brew linkapps` is now retired and deprecated, I propose we update the install instructions, since it currently does not work any more.

This PR edits the README to softlink from `/usr/local/opt` to `/Applications`