### PR TITLE
Fix compatibility of subprocess.check_output in python3/2

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -32,7 +32,7 @@ if not nvim:
     sys.exit(-1)
 
 # Check Neovim version
-ver_str = subprocess.check_output([nvim, '--version']).split('\n', 1)[0]
+ver_str = subprocess.check_output([nvim, '--version']).decode().split('\n', 1)[0]
 if '-dev' in ver_str:
     print(
         "WARNING: Could not determine exact Neovim version. If your Neovim is "
@@ -109,4 +109,4 @@ env.Command(
     'sh makeicons.sh $TARGET $SOURCE'
 )
 
-#  vim: set et fenc=utf-8 ff=unix ft=python sts=4 sw=4 ts=8 : 
+#  vim: set et fenc=utf-8 ff=unix ft=python sts=4 sw=4 ts=8 :


### PR DESCRIPTION
Installing with python3 would cause an error like this

```
VIM=/usr/local/Cellar/neovim/0.2.2_1/share/nvim NVIM=/usr/local/opt/neovim/bin/nvim scons -Q
TypeError: a bytes-like object is required, not 'str':
  File "/private/tmp/neovim-dot-app-20180308-61804-1kii4rn/SConstruct", line 35:
    ver_str = subprocess.check_output([nvim, '--version']).split('\n', 1)[0]
make: *** [all] Error 2
```