### PR TITLE
Fix case in "Split Diff With" to match modern neovim

### DIFF
--- a/res/nvimrc
+++ b/res/nvimrc
@@ -112,7 +112,7 @@ aunmenu File.Open\.\.\.
 aunmenu File.Split-Open\.\.\.
 aunmenu File.Open\ Tab\.\.\.
 aunmenu File.Save\ As\.\.\.
-aunmenu File.Split\ Diff\ with\.\.\.
+aunmenu File.Split\ Diff\ With\.\.\.
 aunmenu File.Split\ Patched\ By\.\.\.
 
 " Exit doesn't belong in the File menu


### PR DESCRIPTION
Changed upstream in v0.2.1:

https://github.com/neovim/neovim/commit/93fb7383a330f03bf64ed5558a8e16ea4c742478#diff-0bf1822437d77cb156948e808487340dR115